### PR TITLE
Updated build configuration property sheets to support WASM static libs

### DIFF
--- a/Build/Config/Configurations.props
+++ b/Build/Config/Configurations.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?> 
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|MSFS">
       <Configuration>Debug</Configuration>

--- a/Build/Config/Cpp.MSFS.WASM.Module.props
+++ b/Build/Config/Cpp.MSFS.WASM.Module.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?> 
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetExt>.wasm</TargetExt>
+  </PropertyGroup>
+</Project>

--- a/Build/Config/Cpp.MSFS.WASM.StaticLibrary.props
+++ b/Build/Config/Cpp.MSFS.WASM.StaticLibrary.props
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?> 
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetExt>.a</TargetExt>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <Link>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+    </Link>
+  </ItemDefinitionGroup>
+</Project>

--- a/Build/Config/Cpp.MSFS.WASM.props
+++ b/Build/Config/Cpp.MSFS.WASM.props
@@ -1,22 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?> 
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Label="Configuration">
-    <PlatformToolset>MSFS</PlatformToolset>
-  </PropertyGroup>
-
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <TargetExt>.wasm</TargetExt>
-    <IncludePath>$(MSFS_IncludePath);%(IncludePath)</IncludePath>
     <PreprocessorDefinitions>__wasi__;_STRING_H_CPLUSPLUS_98_CONFORMANCE_;_WCHAR_H_CPLUSPLUS_98_CONFORMANCE_;_LIBCPP_HAS_NO_THREADS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
-    <Link>
-      <NoEntryPoint>true</NoEntryPoint>
-      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
-    </Link>
     <ClCompile>
       <ExceptionHandling>false</ExceptionHandling>
     </ClCompile>
+    <Link>
+      <NoEntryPoint>true</NoEntryPoint>
+    </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/Build/Config/Cpp.MSFS.props
+++ b/Build/Config/Cpp.MSFS.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?> 
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <IncludePath>$(MSFS_IncludePath);%(IncludePath)</IncludePath>
+  </PropertyGroup>
+</Project>

--- a/Build/Config/Cpp.props
+++ b/Build/Config/Cpp.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?> 
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <DefaultLanguage>en-GB</DefaultLanguage>
     <VCProjectVersion>16.0</VCProjectVersion>
@@ -8,7 +8,7 @@
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
 
-  <PropertyGroup Label="Configuration">
+  <PropertyGroup>
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <UseDebugLibraries Condition="'$(Configuration)' == 'Debug'">true</UseDebugLibraries>
     <UseDebugLibraries Condition="'$(Configuration)' != 'Debug'">false</UseDebugLibraries>
@@ -17,20 +17,17 @@
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
 
+  <Import Project="$(PlatformSettings)" Condition="'$(PlatformSettings)' != ''" />
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
 
   <PropertyGroup>
+    <TargetName>$(ProjectName)</TargetName>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <EnableCOMDATFolding Condition="'$(Configuration)' == 'Release'">true</EnableCOMDATFolding>
-      <OptimizeReferences Condition="'$(Configuration)' == 'Release'">true</OptimizeReferences>
-    </Link>
     <ClCompile>
       <LanguageStandard>stdcpp17</LanguageStandard>
 
@@ -53,14 +50,14 @@
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <TreatWarningAsError>true</TreatWarningAsError>
 
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DebugInformationFormat Condition="'$(Configuration)' == 'Debug'">ProgramDatabase</DebugInformationFormat>
       <ProgramDataBaseFileName>$(IntDir)vc$(PlatformToolsetVersion).pdb</ProgramDataBaseFileName>
     </ClCompile>
+    <Link>
+      <GenerateDebugInformation Condition="'$(Configuration)' == 'Debug'">true</GenerateDebugInformation>
+      <GenerateDebugInformation Condition="'$(Configuration)' == 'Release'">false</GenerateDebugInformation>
+      <EnableCOMDATFolding Condition="'$(Configuration)' == 'Release'">true</EnableCOMDATFolding>
+      <OptimizeReferences Condition="'$(Configuration)' == 'Release'">true</OptimizeReferences>
+    </Link>
   </ItemDefinitionGroup>
-
-  <Import Condition="'$(PathPropsImported)' != 'true'" Project="Path.Props" />
-
-  <PropertyGroup>
-    <TargetName>$(ProjectName)</TargetName>
-  </PropertyGroup>
 </Project>

--- a/Build/Config/Path.props
+++ b/Build/Config/Path.props
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?> 
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <PathPropsImported>true</PathPropsImported>
-  </PropertyGroup>
-  
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <IntDir>$(BuiltDirectory)Int\$(PlatformToolset)\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <OutDir>$(BuiltDirectory)Out\$(PlatformToolset)\$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>

--- a/Build/Config/Platform.MSFS.props
+++ b/Build/Config/Platform.MSFS.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?> 
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PlatformToolset>MSFS</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(MSFSConfigurationType)' != ''">
+    <ConfigurationType>$(MSFSConfigurationType)</ConfigurationType>
+  </PropertyGroup>
+</Project>

--- a/Source/SimCacheModule/Build/SimCacheModule.vcxproj
+++ b/Source/SimCacheModule/Build/SimCacheModule.vcxproj
@@ -1,19 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="Environment">
+    <Import Project="$(SolutionDir)..\Root.props" />
+    <Import Project="$(ConfigDirectory)Configurations.props" />
+  </ImportGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5468B35-BBBD-4C55-97ED-81BFE343B0E4}</ProjectGuid>
     <RootNamespace>Module</RootNamespace>
+    <PlatformSettings>$(ConfigDirectory)Platform.MSFS.props</PlatformSettings>
+    <MSFSConfigurationType>Application</MSFSConfigurationType>
   </PropertyGroup>
-  <ImportGroup Label="PropertySheets">
-    <Import Project="$(SolutionDir)..\Root.props" />
-    <Import Project="$(ConfigDirectory)Configurations.props" />
+  <ImportGroup>
     <Import Project="$(ConfigDirectory)Cpp.props" />
-    <Import Project="$(ConfigDirectory)MSFSWASM.props"/>
+    <Import Project="$(ConfigDirectory)Cpp.MSFS.props" />
+    <Import Project="$(ConfigDirectory)Cpp.MSFS.WASM.props" />
+    <Import Project="$(ConfigDirectory)Cpp.MSFS.WASM.Module.props" />
+    <Import Project="$(ConfigDirectory)Path.props" />
   </ImportGroup>
-  <PropertyGroup Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>
+  <PropertyGroup Label="Configuration" />
   <ItemGroup>
     <ClCompile Include="..\Source\SimCacheModule.cpp" />
   </ItemGroup>


### PR DESCRIPTION
Mostly property sheet changes to ensure the order of items is correct & matches the MSFS WASM template projects.