### PR TITLE
Added a SimCache Module class to own various SimCache subsystems

### DIFF
--- a/Source/SimCacheModule/Build/SimCacheModule.vcxproj
+++ b/Source/SimCacheModule/Build/SimCacheModule.vcxproj
@@ -32,6 +32,10 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\Source\Module.cpp" />
+    <ClCompile Include="..\Source\Module\SimCacheModule.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\Source\Module\SimCacheModule.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Source/SimCacheModule/Build/SimCacheModule.vcxproj.filters
+++ b/Source/SimCacheModule/Build/SimCacheModule.vcxproj.filters
@@ -4,10 +4,21 @@
     <Filter Include="Source">
       <UniqueIdentifier>{e69ee60a-a595-4153-acf0-f9c799af1401}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source\Module">
+      <UniqueIdentifier>{bd4f5947-6af3-4b0c-a65d-91aa6f11bbc6}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\Source\Module.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="..\Source\Module\SimCacheModule.cpp">
+      <Filter>Source\Module</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\Source\Module\SimCacheModule.h">
+      <Filter>Source\Module</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/Source/SimCacheModule/Source/Module.cpp
+++ b/Source/SimCacheModule/Source/Module.cpp
@@ -16,13 +16,26 @@ static std::unique_ptr< SimCacheModule > Module = nullptr;
 extern "C" MSFS_CALLBACK void module_init()
 {
 	Module = std::make_unique< SimCacheModule >();
-	Module->Initialize();
+
+	const bool InitializeSucceeded = Module->Initialize();
+	if ( !InitializeSucceeded )
+	{
+		Module->Uninitialize();
+		Module = nullptr;
+
+		return;
+	}
 }
 
 // -----------------------------------------------------------------------------
 
 extern "C" MSFS_CALLBACK void module_deinit()
 {
+	if ( !Module )
+	{
+		return;
+	}
+
 	Module->Uninitialize();
 	Module = nullptr;
 }

--- a/Source/SimCacheModule/Source/Module.cpp
+++ b/Source/SimCacheModule/Source/Module.cpp
@@ -1,18 +1,30 @@
 ﻿// Copyright (c) 2024 Steven Frost and Orion Lyau
 
+#include "Module/SimCacheModule.h"
+
 #include <MSFS/MSFS.h>
 #include <Utils/WASM/Macros.h>
+
+#include <memory>
+
+// -----------------------------------------------------------------------------
+
+static std::unique_ptr< SimCacheModule > Module = nullptr;
 
 // -----------------------------------------------------------------------------
 
 extern "C" MSFS_CALLBACK void module_init()
 {
+	Module = std::make_unique< SimCacheModule >();
+	Module->Initialize();
 }
 
 // -----------------------------------------------------------------------------
 
 extern "C" MSFS_CALLBACK void module_deinit()
 {
+	Module->Uninitialize();
+	Module = nullptr;
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SimCacheModule/Source/Module/SimCacheModule.cpp
+++ b/Source/SimCacheModule/Source/Module/SimCacheModule.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2024 Steven Frost and Orion Lyau
+
+#include "SimCacheModule.h"
+
+#include <Utils/Event/WASMEventDispatcher.h>
+
+// -----------------------------------------------------------------------------
+
+SimCacheModule::SimCacheModule()
+	: SimConnectClient( nullptr )
+	, JavaScriptEventDispatcher( nullptr )
+{
+}
+
+// -----------------------------------------------------------------------------
+
+SimCacheModule::~SimCacheModule()
+{
+}
+
+// -----------------------------------------------------------------------------
+
+void SimCacheModule::Initialize()
+{
+	InitializeSimConnectClient();
+	InitializeEventDispatchers();
+}
+
+// -----------------------------------------------------------------------------
+
+void SimCacheModule::Uninitialize()
+{
+	UninitializeSimConnectClient();
+	UninitializeEventDispatchers();
+}
+
+// -----------------------------------------------------------------------------
+
+void SimCacheModule::InitializeSimConnectClient()
+{
+	SimConnectClient = SimConnect::MakeSimConnectClient( "SimCache" );
+}
+
+// -----------------------------------------------------------------------------
+
+void SimCacheModule::UninitializeSimConnectClient()
+{
+	if ( !SimConnectClient )
+	{
+		return;
+	}
+
+	SimConnectClient->Uninitialize();
+	SimConnectClient = nullptr;
+}
+
+// -----------------------------------------------------------------------------
+
+void SimCacheModule::InitializeEventDispatchers()
+{
+	JavaScriptEventDispatcher = Utils::MakeWASMEventDispatcher( Utils::EWASMEventDispatcherTarget::JavaScript );
+}
+
+// -----------------------------------------------------------------------------
+
+void SimCacheModule::UninitializeEventDispatchers()
+{
+	if ( !JavaScriptEventDispatcher )
+	{
+		return;
+	}
+
+	JavaScriptEventDispatcher = nullptr;
+}
+
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------

--- a/Source/SimCacheModule/Source/Module/SimCacheModule.cpp
+++ b/Source/SimCacheModule/Source/Module/SimCacheModule.cpp
@@ -20,10 +20,21 @@ SimCacheModule::~SimCacheModule()
 
 // -----------------------------------------------------------------------------
 
-void SimCacheModule::Initialize()
+bool SimCacheModule::Initialize()
 {
-	InitializeSimConnectClient();
-	InitializeEventDispatchers();
+	const bool InitializeSimConnectClientSucceeded = InitializeSimConnectClient();
+	if ( !InitializeSimConnectClientSucceeded )
+	{
+		return false;
+	}
+
+	const bool InitializeEventDispatchersSucceeded = InitializeEventDispatchers();
+	if ( !InitializeEventDispatchersSucceeded )
+	{
+		return false;
+	}
+
+	return true;
 }
 
 // -----------------------------------------------------------------------------
@@ -36,9 +47,15 @@ void SimCacheModule::Uninitialize()
 
 // -----------------------------------------------------------------------------
 
-void SimCacheModule::InitializeSimConnectClient()
+bool SimCacheModule::InitializeSimConnectClient()
 {
 	SimConnectClient = SimConnect::MakeSimConnectClient( "SimCache" );
+	if ( !SimConnectClient )
+	{
+		return false;
+	}
+
+	return SimConnectClient->Initialize();
 }
 
 // -----------------------------------------------------------------------------
@@ -56,9 +73,15 @@ void SimCacheModule::UninitializeSimConnectClient()
 
 // -----------------------------------------------------------------------------
 
-void SimCacheModule::InitializeEventDispatchers()
+bool SimCacheModule::InitializeEventDispatchers()
 {
 	JavaScriptEventDispatcher = Utils::MakeWASMEventDispatcher( Utils::EWASMEventDispatcherTarget::JavaScript );
+	if ( !JavaScriptEventDispatcher )
+	{
+		return false;
+	}
+
+	return true;
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SimCacheModule/Source/Module/SimCacheModule.h
+++ b/Source/SimCacheModule/Source/Module/SimCacheModule.h
@@ -14,15 +14,15 @@ public:
 	SimCacheModule();
 	~SimCacheModule();
 
-	void Initialize();
+	bool Initialize();
 	void Uninitialize();
 
 private:
 
-	void InitializeSimConnectClient();
+	bool InitializeSimConnectClient();
 	void UninitializeSimConnectClient();
 
-	void InitializeEventDispatchers();
+	bool InitializeEventDispatchers();
 	void UninitializeEventDispatchers();
 
 private:

--- a/Source/SimCacheModule/Source/Module/SimCacheModule.h
+++ b/Source/SimCacheModule/Source/Module/SimCacheModule.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2024 Steven Frost and Orion Lyau
+
+#pragma once
+
+#include <SimConnect/SimConnectClient.h>
+#include <Utils/Event/EventDispatcher.h>
+
+// -----------------------------------------------------------------------------
+
+class SimCacheModule
+{
+public:
+
+	SimCacheModule();
+	~SimCacheModule();
+
+	void Initialize();
+	void Uninitialize();
+
+private:
+
+	void InitializeSimConnectClient();
+	void UninitializeSimConnectClient();
+
+	void InitializeEventDispatchers();
+	void UninitializeEventDispatchers();
+
+private:
+
+	std::shared_ptr< SimConnect::ISimConnectClient >	SimConnectClient;
+	std::shared_ptr< Utils::EventDispatcher >			JavaScriptEventDispatcher;
+
+};
+
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------


### PR DESCRIPTION
This doesn't do much at the moment, but the general idea is that this will hold all of the subsystems that SimCache has (Cache manager, Player tracker, Cache Tracker, SimConnect Instance, Event Dispatchers, etc.).

I'm going to explore viewmodels for contextual event binding as well, the general idea is that this class will own those as well.

For now, I just added the SimConnectClient and a JS Event Dispatcher here but it will grow over time.