### PR TITLE
Update InGamePanel for SimCache.CacheFoundEvent

### DIFF
--- a/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.css
+++ b/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.css
@@ -40,11 +40,11 @@ body {
 }
 
 #simcache-container>hgroup>*:first-child {
-    margin: 0 0 0.4rem 0;
+    margin: 0 0 0.35rem 0;
 }
 
 #simcache-container>hgroup>*:last-child {
-    margin: 0.4rem 0 0 0;
+    margin: 0.35rem 0 0 0;
 }
 
 #simcache-container>*:last-child {
@@ -68,19 +68,27 @@ body {
     z-index: 1;
 }
 
-#airplane-shadow {
+#central-shadow {
     z-index: 2;
     --shadow: drop-shadow(0 0 2px rgba(0, 0, 0, 0.67));
     filter: var(--shadow);
     -webkit-filter: var(--shadow);
 }
 
-#airplane {
+#central {
     z-index: 1;
+}
+
+.airplane {
     width: 24px;
     height: 24px;
     background-color: #f8f8f8;
     --airplane: path("M22,16v-2l-8.5-5V3.5C13.5,2.67,12.83,2,12,2s-1.5,0.67-1.5,1.5V9L2,14v2l8.5-2.5V19L8,20.5L8,22l4-1l4,1l0-1.5L13.5,19 v-5.5L22,16z");
     -webkit-clip-path: var(--airplane);
     clip-path: var(--airplane);
+}
+
+.checkmark {
+    color: #f8f8f8;
+    font-size: 3rem;
 }

--- a/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.css
+++ b/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.css
@@ -6,13 +6,14 @@ body {
 }
 
 #simcache-container {
+    margin-top: auto;
     margin-left: auto;
     display: flex;
     align-items: center;
     justify-content: center;
     text-align: right;
     box-sizing: border-box;
-    padding: 1rem;
+    padding: 1.5rem;
     border: none;
 }
 
@@ -22,8 +23,7 @@ body {
     -webkit-filter: var(--shadow);
 }
 
-#simcache-container h2 {
-    margin: 0;
+#simcache-container h1 {
     padding: 0;
     font-size: 1.272rem;
     --textColor: #ffe8b2;
@@ -31,13 +31,20 @@ body {
 }
 
 #simcache-container p {
-    margin: 0;
     padding: 0;
     font-weight: 600;
     --textColor: #f8f8f8;
     color: var(--textColor);
     --fontSizeParagraph: 1.128rem;
     font-size: var(--fontSizeParagraph);
+}
+
+#simcache-container>hgroup>*:first-child {
+    margin: 0 0 0.4rem 0;
+}
+
+#simcache-container>hgroup>*:last-child {
+    margin: 0.4rem 0 0 0;
 }
 
 #simcache-container>*:last-child {

--- a/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.html
+++ b/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.html
@@ -37,9 +37,10 @@
                             <circle cx="50%" cy="50%" r="40" stroke="#f8f8f8" stroke-width="2" fill="none" />
                             <circle cx="50%" cy="50%" r="31" stroke="#f8f8f8" stroke-width="2" fill="none" />
                             <circle cx="50%" cy="50%" r="22" stroke="#f8f8f8" stroke-width="2" fill="none" />
+                            <circle id="green-circle" cx="50%" cy="50%" r="0" fill="#a1db7b" fill-opacity="0.8" />
                         </svg>
-                        <div id="airplane-shadow">
-                            <div id="airplane"></div>
+                        <div id="central-shadow">
+                            <div id="central" class="airplane"></div>
                         </div>
                     </div>
                 </div>

--- a/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.html
+++ b/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.html
@@ -26,7 +26,7 @@
             <ui-element style="display: flex; justify-content: right;">
                 <div id="simcache-container" class="shadow">
                     <hgroup>
-                        <h2 id="cache-title"></h2>
+                        <h1 id="cache-title"></h1>
                         <p id="cache-subtitle"></p>
                     </hgroup>
                     <div class="annuli-container">

--- a/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.js
+++ b/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.js
@@ -14,6 +14,8 @@ class SimCachePanel extends UIElement {
         this.m_titleElement = document.getElementById("cache-title");
         this.m_subtitleElement = document.getElementById("cache-subtitle");
         this.m_annulusElement = document.getElementById("inner-annulus");
+        this.m_greenCircleElement = document.getElementById("green-circle");
+        this.m_centralElement = document.getElementById("central");
 
         Promise.all([
             this.registerCommBusListenerAsync()
@@ -50,9 +52,18 @@ class SimCachePanel extends UIElement {
         this.CommBusListener.callWasm("SimCache.TrackerLoadedEvent", "");
     }
 
+    cancelPendingClose() {
+        // TODO: if a new cache is selected in the meantime, make sure to cancel the pending close
+        clearInterval(this.m_timeoutID);
+        this.m_greenCircleElement.setAttributeNS(null, "r", 0);
+        this.m_centralElement.className = "airplane";
+    }
+
     onCacheFoundEvent(data) {
+        this.m_greenCircleElement.setAttributeNS(null, "r", 49);
         this.m_subtitleElement.innerText = "Cache collected";
-        // TODO: if a new cache is selected in the meantime, make sure to cancel the pending close using clearTimeout
+        this.m_centralElement.className = "checkmark";
+        this.m_centralElement.innerHTML = "&#10004;";
         this.m_timeoutID = setTimeout(() => {
             this.m_ingameUI.closePanel();
         }, 5000);

--- a/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.js
+++ b/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.js
@@ -57,6 +57,7 @@ class SimCachePanel extends UIElement {
         clearInterval(this.m_timeoutID);
         this.m_greenCircleElement.setAttributeNS(null, "r", 0);
         this.m_centralElement.className = "airplane";
+        this.m_centralElement.innerHTML = "";
     }
 
     onCacheFoundEvent(data) {

--- a/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.js
+++ b/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.js
@@ -8,7 +8,9 @@ class SimCachePanel extends UIElement {
 
     connectedCallback() {
         this.m_connected = true;
+        this.m_timeoutID = null;
 
+        this.m_ingameUI = this.querySelector("ingame-ui");
         this.m_titleElement = document.getElementById("cache-title");
         this.m_subtitleElement = document.getElementById("cache-subtitle");
         this.m_annulusElement = document.getElementById("inner-annulus");
@@ -44,7 +46,16 @@ class SimCachePanel extends UIElement {
     }
 
     onSubsystemsInitialized() {
+        this.CommBusListener.on("SimCache.CacheFoundEvent", this.onCacheFoundEvent.bind(this));
         this.CommBusListener.callWasm("SimCache.TrackerLoadedEvent", "");
+    }
+
+    onCacheFoundEvent(data) {
+        this.m_subtitleElement.innerText = "Cache collected";
+        // TODO: if a new cache is selected in the meantime, make sure to cancel the pending close using clearTimeout
+        this.m_timeoutID = setTimeout(() => {
+            this.m_ingameUI.closePanel();
+        }, 5000);
     }
 
     updateCacheTitle(title) {


### PR DESCRIPTION
* Set up listener for `SimCache.CacheFoundEvent`
* Add UI for cache found state (stays for 5 seconds, then automatically closes the tracker)
* Add function to cancel pending close and remove changes for cache found state
* General improvements to InGamePanel markup and style
    * Improved semantics by using `h1` (as the title is the only heading in the panel's HTML document)
    * Added more space between the heading and the subtitle
    * Increased padding to move so panel isn't as close to the right edge of the screen
    * Shifted downwards to ensure space is clear for the default MSFS Toolbar