### PR TITLE
Update InGamePanel for SimCache.TrackedCacheDataUpdatedEvent

### DIFF
--- a/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.css
+++ b/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.css
@@ -23,6 +23,11 @@ body {
     -webkit-filter: var(--shadow);
 }
 
+.display-none {
+    display: none;
+    visibility: hidden;
+}
+
 #simcache-container h1 {
     padding: 0;
     font-size: 1.272rem;

--- a/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.html
+++ b/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.html
@@ -24,7 +24,7 @@
         <ingame-ui id="SimCache_Frame" panel-id="PANEL_SIMCACHE" class="ingameUiFrame panelInvisible" title="SimCache"
             content-fit="true" min-width="40" resize="x">
             <ui-element style="display: flex; justify-content: right;">
-                <div id="simcache-container" class="shadow">
+                <div id="simcache-container" class="shadow display-none">
                     <hgroup>
                         <h1 id="cache-title"></h1>
                         <p id="cache-subtitle"></p>

--- a/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.js
+++ b/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.js
@@ -38,9 +38,8 @@ class SimCachePanel extends UIElement {
             this.cancelPendingClose();
         }
         const data = JSON.parse(eventData);
-        this.m_titleElement.innerText = data.title;
-        this.updateRange(data.distance_meters);
-        this.m_containerElement.classList.remove("display-none");
+        this.updateUIElements(data.title, data.distance_meters);
+        this.makeVisible();
     }
 
     cancelPendingClose() {
@@ -61,7 +60,22 @@ class SimCachePanel extends UIElement {
         }, 5000);
     }
 
-    updateRange(distanceMeters) {
+    updateUIElements(title, distanceMeters) {
+        this.updateCacheTitle(title);
+        this.updateCacheRange(distanceMeters);
+    }
+
+    makeVisible() {
+        // ensure the panel is visible (since display-none is set in the html upon load)
+        // (this is done to prevent the panel from appearing before it's fully initialized)
+        this.m_containerElement.classList.remove("display-none");
+    }
+
+    updateCacheTitle(title) {
+        this.m_titleElement.innerText = title;
+    }
+
+    updateCacheRange(distanceMeters) {
         const piecewiseRange = this.getPiecewiseRange(distanceMeters);
         this.m_subtitleElement.innerText = this.getSubtitle(piecewiseRange);
         this.m_annulusElement.setAttributeNS(null, "r", this.getAnnulusInnerRadius(piecewiseRange));

--- a/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.js
+++ b/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.js
@@ -3,14 +3,13 @@
 class SimCachePanel extends UIElement {
     constructor() {
         super();
-        this.m_connected = false;
     }
 
     connectedCallback() {
-        this.m_connected = true;
         this.m_timeoutID = null;
 
         this.m_ingameUI = this.querySelector("ingame-ui");
+        this.m_containerElement = document.getElementById("simcache-container");
         this.m_titleElement = document.getElementById("cache-title");
         this.m_subtitleElement = document.getElementById("cache-subtitle");
         this.m_annulusElement = document.getElementById("inner-annulus");
@@ -20,25 +19,6 @@ class SimCachePanel extends UIElement {
         Promise.all([
             this.registerCommBusListenerAsync()
         ]).then((values) => this.onSubsystemsInitialized());
-
-        // TODO: remove placeholder when CacheDataChangedEvent is set up
-        this.updateCacheTitle("Cache Title Placeholder");
-        this.updateRange(100000);
-
-        let updateLoop = () => {
-            if (!this.m_connected) {
-                return;
-            }
-
-            try {
-                this.UpdatePanel();
-            }
-            catch (Error) {
-                console.error(document.title + " : " + Error);
-            }
-            requestAnimationFrame(updateLoop);
-        };
-        requestAnimationFrame(updateLoop);
     }
 
     registerCommBusListenerAsync() {
@@ -48,13 +28,24 @@ class SimCachePanel extends UIElement {
     }
 
     onSubsystemsInitialized() {
+        this.CommBusListener.on("SimCache.TrackedCacheDataUpdatedEvent", this.onTrackedCacheDataUpdatedEvent.bind(this));
         this.CommBusListener.on("SimCache.CacheFoundEvent", this.onCacheFoundEvent.bind(this));
         this.CommBusListener.callWasm("SimCache.TrackerLoadedEvent", "");
     }
 
+    onTrackedCacheDataUpdatedEvent(eventData) {
+        if (this.m_timeoutID !== null) {
+            this.cancelPendingClose();
+        }
+        const data = JSON.parse(eventData);
+        this.m_titleElement.innerText = data.title;
+        this.updateRange(data.distance_meters);
+        this.m_containerElement.classList.remove("display-none");
+    }
+
     cancelPendingClose() {
-        // TODO: if a new cache is selected in the meantime, make sure to cancel the pending close
         clearInterval(this.m_timeoutID);
+        this.m_timeoutID = null;
         this.m_greenCircleElement.setAttributeNS(null, "r", 0);
         this.m_centralElement.className = "airplane";
         this.m_centralElement.innerHTML = "";
@@ -70,19 +61,10 @@ class SimCachePanel extends UIElement {
         }, 5000);
     }
 
-    updateCacheTitle(title) {
-        this.m_titleElement.innerText = title;
-    }
-
     updateRange(distanceMeters) {
         const piecewiseRange = this.getPiecewiseRange(distanceMeters);
-        if (this.m_currentPiecewiseRange !== piecewiseRange) {
-            this.m_currentPiecewiseRange = piecewiseRange;
-
-            // entered a new annulus; update things as necessary
-            this.m_subtitleElement.innerText = this.getSubtitle(piecewiseRange);
-            this.m_annulusElement.setAttributeNS(null, "r", this.getAnnulusInnerRadius(piecewiseRange));
-        }
+        this.m_subtitleElement.innerText = this.getSubtitle(piecewiseRange);
+        this.m_annulusElement.setAttributeNS(null, "r", this.getAnnulusInnerRadius(piecewiseRange));
     }
 
     getSubtitle(piecewiseRange) {
@@ -121,10 +103,6 @@ class SimCachePanel extends UIElement {
             default:
                 return 49;
         }
-    }
-
-    UpdatePanel() {
-        // TODO: add items to repeat within update loop
     }
 
 }


### PR DESCRIPTION
- Add listener for SimCache.TrackedCacheDataUpdatedEvent
- Prevent InGamePanel from displaying until first receiving tracked cache data
- Ensure pending close is cancelled when receiving tracked cache data updated event
- Remove placeholder text
- Remove update loop (panel is only updated via CommBus event)
- Simplify range update code (since view model only sends updates when appropriate)