### PR TITLE
Initial object serialisation implementation

### DIFF
--- a/Source/SimCacheModule/Source/Events/TrackerLoadedEvent.h
+++ b/Source/SimCacheModule/Source/Events/TrackerLoadedEvent.h
@@ -11,8 +11,8 @@ class TrackerLoadedEvent
 {
 public:
 
-	virtual std::string Serialise() const override final { return {}; }
-	virtual void Deserialise( const std::string& Data ) override final {}
+	virtual bool Serialise( Utils::Serialisation::Writer& Writer ) const override final { return true; }
+	virtual bool Deserialise( Utils::Serialisation::Reader& Reader ) override final { return true; }
 };
 
 // -----------------------------------------------------------------------------

--- a/Source/Utils/Build/Utils.vcxproj
+++ b/Source/Utils/Build/Utils.vcxproj
@@ -26,15 +26,23 @@
     <ClInclude Include="..\Inc\Utils\Event\EventHandle.h" />
     <ClInclude Include="..\Inc\Utils\Event\WASMEventDispatcher.h" />
     <ClInclude Include="..\Inc\Utils\Logging\Log.h" />
+    <ClInclude Include="..\Inc\Utils\Serialisation\JSON\JSONReader.h" />
+    <ClInclude Include="..\Inc\Utils\Serialisation\JSON\JSONWriter.h" />
+    <ClInclude Include="..\Inc\Utils\Serialisation\Reader.h" />
     <ClInclude Include="..\Inc\Utils\Serialisation\Serialisable.h" />
+    <ClInclude Include="..\Inc\Utils\Serialisation\Writer.h" />
     <ClInclude Include="..\Inc\Utils\Time\DateTime.h" />
     <ClInclude Include="..\Inc\Utils\WASM\Macros.h" />
     <ClInclude Include="..\Source\Event\WASMEventDispatcher.h" />
+    <ClInclude Include="..\Source\Serialisation\JSON\JSONReader.h" />
+    <ClInclude Include="..\Source\Serialisation\Reader.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\Source\Event\EventHandle.cpp" />
     <ClCompile Include="..\Source\Event\WASMEventDispatcher.cpp" />
     <ClCompile Include="..\Source\Logging\Log.cpp" />
+    <ClCompile Include="..\Source\Serialisation\JSON\JSONReader.cpp" />
+    <ClCompile Include="..\Source\Serialisation\JSON\JSONWriter.cpp" />
     <ClCompile Include="..\Source\Time\DateTime.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Source/Utils/Build/Utils.vcxproj.filters
+++ b/Source/Utils/Build/Utils.vcxproj.filters
@@ -31,6 +31,18 @@
     <ClInclude Include="..\Inc\Utils\Time\DateTime.h">
       <Filter>Include\Utils\Time</Filter>
     </ClInclude>
+    <ClInclude Include="..\Inc\Utils\Serialisation\Writer.h">
+      <Filter>Include\Utils\Serialisation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Inc\Utils\Serialisation\JSON\JSONWriter.h">
+      <Filter>Include\Utils\Serialisation\JSON</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Inc\Utils\Serialisation\Reader.h">
+      <Filter>Include\Utils\Serialisation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Inc\Utils\Serialisation\JSON\JSONReader.h">
+      <Filter>Include\Utils\Serialisation\JSON</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source">
@@ -69,6 +81,15 @@
     <Filter Include="Source\Time">
       <UniqueIdentifier>{d6775f97-4f46-4298-8eec-2fcfedaf1481}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Include\Utils\Serialisation\JSON">
+      <UniqueIdentifier>{18ad732e-b9b3-4d2c-93c8-5414a1c8feb9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source\Serialisation">
+      <UniqueIdentifier>{b22ba56d-2431-48b4-9946-7d2d7eb7a7d2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source\Serialisation\JSON">
+      <UniqueIdentifier>{50ff62f3-d4a5-4dc9-8fd3-c86ee0e3f75e}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\Source\Event\EventHandle.cpp">
@@ -82,6 +103,12 @@
     </ClCompile>
     <ClCompile Include="..\Source\Time\DateTime.cpp">
       <Filter>Source\Time</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Source\Serialisation\JSON\JSONWriter.cpp">
+      <Filter>Source\Serialisation\JSON</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Source\Serialisation\JSON\JSONReader.cpp">
+      <Filter>Source\Serialisation\JSON</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/Source/Utils/Inc/Utils/Event/Event.h
+++ b/Source/Utils/Inc/Utils/Event/Event.h
@@ -12,7 +12,7 @@ namespace Utils
 // -----------------------------------------------------------------------------
 
 struct Event
-	: public ISerialisable
+	: public Serialisation::ISerialisable
 {
 };
 

--- a/Source/Utils/Inc/Utils/Event/EventDispatcher.h
+++ b/Source/Utils/Inc/Utils/Event/EventDispatcher.h
@@ -45,8 +45,11 @@ public:
 			{
 				TEvent NewEvent;
 
-				Utils::Serialisation::JSONReader Reader( EventData );
-				NewEvent.Deserialise( Reader );
+				if ( !EventData.empty() )
+				{
+					Utils::Serialisation::JSONReader Reader( EventData );
+					NewEvent.Deserialise( Reader );
+				}
 
 				Callback( NewEvent );
 			}

--- a/Source/Utils/Inc/Utils/Event/EventDispatcher.h
+++ b/Source/Utils/Inc/Utils/Event/EventDispatcher.h
@@ -4,6 +4,7 @@
 
 #include <Utils/Event/Event.h>
 #include <Utils/Event/EventHandle.h>
+#include <Utils/Serialisation/JSON/JSONReader.h>
 #include <Utils/WASM/Macros.h>
 
 #include <functional>
@@ -43,7 +44,9 @@ public:
 			[ Callback ]( const std::string& EventData )
 			{
 				TEvent NewEvent;
-				NewEvent.Deserialise( EventData );
+
+				Utils::Serialisation::JSONReader Reader( EventData );
+				NewEvent.Deserialise( Reader );
 
 				Callback( NewEvent );
 			}

--- a/Source/Utils/Inc/Utils/Serialisation/JSON/JSONReader.h
+++ b/Source/Utils/Inc/Utils/Serialisation/JSON/JSONReader.h
@@ -1,0 +1,103 @@
+// Copyright (c) 2024 Steven Frost and Orion Lyau
+
+#pragma once
+
+#include <Utils/Serialisation/Reader.h>
+
+#include <rapidjson/document.h>
+#include <rapidjson/pointer.h>
+
+#include <stack>
+#include <utility>
+
+// -----------------------------------------------------------------------------
+
+namespace Utils
+{
+namespace Serialisation
+{
+
+// -----------------------------------------------------------------------------
+
+class JSONReader
+	: public Reader
+{
+public:
+
+	JSONReader( const std::string& Data );
+
+public:
+
+	virtual bool ReadProperty( const PropertyName& Name, bool& Value ) override final;
+	virtual bool ReadProperty( const PropertyName& Name, float& Value ) override final;
+	virtual bool ReadProperty( const PropertyName& Name, double& Value ) override final;
+
+	virtual bool ReadProperty( const PropertyName& Name, int8_t& Value ) override final;
+	virtual bool ReadProperty( const PropertyName& Name, int16_t& Value ) override final;
+	virtual bool ReadProperty( const PropertyName& Name, int32_t& Value ) override final;
+	virtual bool ReadProperty( const PropertyName& Name, int64_t& Value ) override final;
+
+	virtual bool ReadProperty( const PropertyName& Name, uint8_t& Value ) override final;
+	virtual bool ReadProperty( const PropertyName& Name, uint16_t& Value ) override final;
+	virtual bool ReadProperty( const PropertyName& Name, uint32_t& Value ) override final;
+	virtual bool ReadProperty( const PropertyName& Name, uint64_t& Value ) override final;
+
+	virtual bool ReadProperty( const PropertyName& Name, std::string& Value ) override final;
+
+private:
+
+	virtual void BeginObject( const PropertyName& Name ) override final;
+	virtual void EndObject() override final;
+
+private:
+
+	virtual size_t GetArraySize() const override final;
+
+	virtual void BeginArray( const PropertyName& Name ) override final;
+	virtual void EndArray() override final;
+
+	virtual void BeginArrayObject( const size_t Index ) override final;
+	virtual void EndArrayObject() override final;
+
+	virtual bool ReadArrayElement( bool& Value ) override final;
+	virtual bool ReadArrayElement( float& Value ) override final;
+	virtual bool ReadArrayElement( double& Value ) override final;
+
+	virtual bool ReadArrayElement( int8_t& Value ) override final;
+	virtual bool ReadArrayElement( int16_t& Value ) override final;
+	virtual bool ReadArrayElement( int32_t& Value ) override final;
+	virtual bool ReadArrayElement( int64_t& Value ) override final;
+
+	virtual bool ReadArrayElement( uint8_t& Value ) override final;
+	virtual bool ReadArrayElement( uint16_t& Value ) override final;
+	virtual bool ReadArrayElement( uint32_t& Value ) override final;
+	virtual bool ReadArrayElement( uint64_t& Value ) override final;
+
+	virtual bool ReadArrayElement( std::string& Value ) override final;
+
+private:
+
+	std::string GetCurrentPath() const;
+
+	rapidjson::Value* GetCurrentObject();
+	const rapidjson::Value* GetCurrentObject() const;
+
+	rapidjson::Value* GetMember( const PropertyName& Name );
+
+private:
+
+	typedef std::string PathName;
+	typedef std::pair< PathName, rapidjson::Pointer > NamedPointer;
+
+	rapidjson::Document			JsonDocument;
+	std::stack< NamedPointer >	Stack;
+};
+
+// -----------------------------------------------------------------------------
+
+} // namespace Serialisation
+} // namespace Utils
+
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------

--- a/Source/Utils/Inc/Utils/Serialisation/JSON/JSONWriter.h
+++ b/Source/Utils/Inc/Utils/Serialisation/JSON/JSONWriter.h
@@ -1,0 +1,100 @@
+// Copyright (c) 2024 Steven Frost and Orion Lyau
+
+#pragma once
+
+#include <Utils/Serialisation/Writer.h>
+
+#include <rapidjson/document.h>
+#include <rapidjson/pointer.h>
+
+#include <stack>
+#include <utility>
+
+// -----------------------------------------------------------------------------
+
+namespace Utils
+{
+namespace Serialisation
+{
+
+// -----------------------------------------------------------------------------
+
+class JSONWriter
+	: public Writer
+{
+public:
+
+	JSONWriter();
+
+	virtual bool WriteProperty( const PropertyName& Name, const bool Value ) override final;
+	virtual bool WriteProperty( const PropertyName& Name, const float Value ) override final;
+	virtual bool WriteProperty( const PropertyName& Name, const double Value ) override final;
+
+	virtual bool WriteProperty( const PropertyName& Name, const int8_t Value ) override final;
+	virtual bool WriteProperty( const PropertyName& Name, const int16_t Value ) override final;
+	virtual bool WriteProperty( const PropertyName& Name, const int32_t Value ) override final;
+	virtual bool WriteProperty( const PropertyName& Name, const int64_t Value ) override final;
+
+	virtual bool WriteProperty( const PropertyName& Name, const uint8_t Value ) override final;
+	virtual bool WriteProperty( const PropertyName& Name, const uint16_t Value ) override final;
+	virtual bool WriteProperty( const PropertyName& Name, const uint32_t Value ) override final;
+	virtual bool WriteProperty( const PropertyName& Name, const uint64_t Value ) override final;
+
+	virtual bool WriteProperty( const PropertyName& Name, const std::string& Value ) override final;
+
+	virtual std::string ToString() const override final;
+
+private:
+
+	virtual void BeginObject( const PropertyName& Name ) override final;
+	virtual void EndObject() override final;
+
+private:
+
+	virtual void BeginArray( const PropertyName& Name ) override final;
+	virtual void EndArray() override final;
+
+	virtual void BeginArrayObject() override final;
+	virtual void EndArrayObject() override final;
+
+	virtual bool WriteArrayElement( const bool Value ) override final;
+	virtual bool WriteArrayElement( const float Value ) override final;
+	virtual bool WriteArrayElement( const double Value ) override final;
+
+	virtual bool WriteArrayElement( const int8_t Value ) override final;
+	virtual bool WriteArrayElement( const int16_t Value ) override final;
+	virtual bool WriteArrayElement( const int32_t Value ) override final;
+	virtual bool WriteArrayElement( const int64_t Value ) override final;
+
+	virtual bool WriteArrayElement( const uint8_t Value ) override final;
+	virtual bool WriteArrayElement( const uint16_t Value ) override final;
+	virtual bool WriteArrayElement( const uint32_t Value ) override final;
+	virtual bool WriteArrayElement( const uint64_t Value ) override final;
+
+	virtual bool WriteArrayElement( const std::string& Value ) override final;
+
+private:
+
+	std::string CurrentPath() const;
+
+	rapidjson::Value* CurrentObject();
+
+private:
+
+	typedef std::string PathName;
+	typedef std::pair< PathName, rapidjson::Pointer > NamedPointer;
+
+	rapidjson::Document					JsonDocument;
+	rapidjson::MemoryPoolAllocator<>*	Allocator;
+
+	std::stack< NamedPointer >			Stack;
+};
+
+// -----------------------------------------------------------------------------
+
+} // namespace Serialisation
+} // namespace Utils
+
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------

--- a/Source/Utils/Inc/Utils/Serialisation/Reader.h
+++ b/Source/Utils/Inc/Utils/Serialisation/Reader.h
@@ -1,0 +1,144 @@
+// Copyright (c) 2024 Steven Frost and Orion Lyau
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+
+// -----------------------------------------------------------------------------
+
+namespace Utils
+{
+namespace Serialisation
+{
+
+// -----------------------------------------------------------------------------
+
+class ISerialisable;
+
+// -----------------------------------------------------------------------------
+
+class Reader
+{
+public:
+
+	typedef std::string PropertyName;
+
+	virtual bool ReadProperty( const PropertyName& Name, bool& Value ) = 0;
+	virtual bool ReadProperty( const PropertyName& Name, float& Value ) = 0;
+	virtual bool ReadProperty( const PropertyName& Name, double& Value ) = 0;
+
+	virtual bool ReadProperty( const PropertyName& Name, int8_t& Value ) = 0;
+	virtual bool ReadProperty( const PropertyName& Name, int16_t& Value ) = 0;
+	virtual bool ReadProperty( const PropertyName& Name, int32_t& Value ) = 0;
+	virtual bool ReadProperty( const PropertyName& Name, int64_t& Value ) = 0;
+
+	virtual bool ReadProperty( const PropertyName& Name, uint8_t& Value ) = 0;
+	virtual bool ReadProperty( const PropertyName& Name, uint16_t& Value ) = 0;
+	virtual bool ReadProperty( const PropertyName& Name, uint32_t& Value ) = 0;
+	virtual bool ReadProperty( const PropertyName& Name, uint64_t& Value ) = 0;
+
+	virtual bool ReadProperty( const PropertyName& Name, std::string& Value ) = 0;
+
+	template< class TValue >
+	auto ReadProperty( const PropertyName& Name, TValue& Value ) -> typename std::enable_if< std::is_class< TValue >::value, bool >::type
+	{
+		static_assert( std::is_base_of< ISerialisable, TValue >::value, "TValue must be derived from ISerialisable" );
+
+		BeginObject( Name );
+		const bool Success = Value.Deserialise( *this );
+		EndObject();
+
+		return Success;
+	}
+
+	template< class TElement >
+	auto ReadProperty( const PropertyName& Name, std::vector< TElement >& Array ) -> typename std::enable_if< std::is_base_of< ISerialisable, TElement >::value, bool >::type
+	{
+		bool Success = true;
+
+		BeginArray( Name );
+
+		const size_t ArraySize = GetArraySize();
+
+		Array.clear();
+		Array.resize( ArraySize );
+
+		for ( size_t Index = 0; Index < ArraySize; ++Index )
+		{
+			BeginArrayObject( Index );
+			Success &= Array[ Index ].Deserialise( *this );
+			EndArrayObject();
+		}
+
+		EndArray();
+
+		return Success;
+	}
+
+	template< class TElement >
+	auto ReadProperty( const PropertyName& Name, std::vector< TElement >& Array ) -> typename std::enable_if< !std::is_base_of< ISerialisable, TElement >::value, bool >::type
+	{
+		bool Success = true;
+
+		BeginArray( Name );
+
+		const size_t ArraySize = GetArraySize();
+
+		Array.clear();
+		Array.resize( ArraySize );
+
+		for ( size_t Index = 0; Index < ArraySize; ++Index )
+		{
+			BeginArrayObject( Index );
+			Success &= ReadArrayElement( Array[ Index ] );
+			EndArrayObject();
+		}
+
+		EndArray();
+
+		return Success;
+	}
+
+private:
+
+	virtual void BeginObject( const PropertyName& Name ) = 0;
+	virtual void EndObject() = 0;
+
+private:
+
+	virtual size_t GetArraySize() const = 0;
+
+	virtual void BeginArray( const PropertyName& Name ) = 0;
+	virtual void EndArray() = 0;
+
+	virtual void BeginArrayObject( const size_t Index ) = 0;
+	virtual void EndArrayObject() = 0;
+
+	virtual bool ReadArrayElement( bool& Value ) = 0;
+	virtual bool ReadArrayElement( float& Value ) = 0;
+	virtual bool ReadArrayElement( double& Value ) = 0;
+
+	virtual bool ReadArrayElement( int8_t& Value ) = 0;
+	virtual bool ReadArrayElement( int16_t& Value ) = 0;
+	virtual bool ReadArrayElement( int32_t& Value ) = 0;
+	virtual bool ReadArrayElement( int64_t& Value ) = 0;
+
+	virtual bool ReadArrayElement( uint8_t& Value ) = 0;
+	virtual bool ReadArrayElement( uint16_t& Value ) = 0;
+	virtual bool ReadArrayElement( uint32_t& Value ) = 0;
+	virtual bool ReadArrayElement( uint64_t& Value ) = 0;
+
+	virtual bool ReadArrayElement( std::string& Value ) = 0;
+};
+
+// -----------------------------------------------------------------------------
+
+} // namespace Serialisation
+} // namespace Utils
+
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------

--- a/Source/Utils/Inc/Utils/Serialisation/Serialisable.h
+++ b/Source/Utils/Inc/Utils/Serialisation/Serialisable.h
@@ -2,11 +2,16 @@
 
 #pragma once
 
+#include <Utils/Serialisation/Reader.h>
+#include <Utils/Serialisation/Writer.h>
+
 #include <string>
 
 // -----------------------------------------------------------------------------
 
 namespace Utils
+{
+namespace Serialisation
 {
 
 // -----------------------------------------------------------------------------
@@ -15,13 +20,16 @@ class ISerialisable
 {
 public:
 
-	virtual std::string Serialise() const = 0;
-	virtual void Deserialise( const std::string& Data ) = 0;
+	virtual ~ISerialisable() = default;
+
+	virtual bool Serialise( Writer& Writer ) const = 0;
+	virtual bool Deserialise( Reader& Reader ) = 0;
 
 };
 
 // -----------------------------------------------------------------------------
 
+} // namespace Serialisation
 } // namespace Utils
 
 // -----------------------------------------------------------------------------

--- a/Source/Utils/Inc/Utils/Serialisation/Writer.h
+++ b/Source/Utils/Inc/Utils/Serialisation/Writer.h
@@ -1,0 +1,128 @@
+// Copyright (c) 2024 Steven Frost and Orion Lyau
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+
+// -----------------------------------------------------------------------------
+
+namespace Utils
+{
+namespace Serialisation
+{
+
+// -----------------------------------------------------------------------------
+
+class ISerialisable;
+
+// -----------------------------------------------------------------------------
+
+class Writer
+{
+public:
+
+	typedef std::string PropertyName;
+
+	virtual bool WriteProperty( const PropertyName& Name, const bool Value ) = 0;
+	virtual bool WriteProperty( const PropertyName& Name, const float Value ) = 0;
+	virtual bool WriteProperty( const PropertyName& Name, const double Value ) = 0;
+
+	virtual bool WriteProperty( const PropertyName& Name, const int8_t Value ) = 0;
+	virtual bool WriteProperty( const PropertyName& Name, const int16_t Value ) = 0;
+	virtual bool WriteProperty( const PropertyName& Name, const int32_t Value ) = 0;
+	virtual bool WriteProperty( const PropertyName& Name, const int64_t Value ) = 0;
+
+	virtual bool WriteProperty( const PropertyName& Name, const uint8_t Value ) = 0;
+	virtual bool WriteProperty( const PropertyName& Name, const uint16_t Value ) = 0;
+	virtual bool WriteProperty( const PropertyName& Name, const uint32_t Value ) = 0;
+	virtual bool WriteProperty( const PropertyName& Name, const uint64_t Value ) = 0;
+
+	virtual bool WriteProperty( const PropertyName& Name, const std::string& Value ) = 0;
+
+	template< class TValue >
+	auto WriteProperty( const PropertyName& Name, const TValue& Value ) -> typename std::enable_if< std::is_class< TValue >::value, bool >::type
+	{
+		static_assert( std::is_base_of< ISerialisable, TValue >::value, "TValue must be a Serialisable type" );
+
+		BeginObject( Name );
+		const bool Success = Value.Serialise( *this );
+		EndObject();
+
+		return Success;
+	}
+
+	template< class TElement >
+	auto WriteProperty( const PropertyName& Name, const std::vector< TElement >& Array ) -> typename std::enable_if< std::is_base_of< ISerialisable, TElement >::value, bool >::type
+	{
+		bool Success = true;
+
+		BeginArray( Name );
+		for ( const auto& Element : Array )
+		{
+			BeginArrayObject();
+			Success &= Element.Serialise( *this );
+			EndArrayObject();
+		}
+		EndArray();
+
+		return Success;
+	}
+
+	template< class TElement >
+	auto WriteProperty( const PropertyName& Name, const std::vector< TElement >& Array ) -> typename std::enable_if< !std::is_base_of< ISerialisable, TElement >::value, bool >::type
+	{
+		bool Success = true;
+
+		BeginArray( Name );
+		for ( const auto& Element : Array )
+		{
+			Success &= WriteArrayElement( Element );
+		}
+		EndArray();
+
+		return Success;
+	}
+
+	virtual std::string ToString() const = 0;
+
+private:
+
+	virtual void BeginObject( const PropertyName& Name ) = 0;
+	virtual void EndObject() = 0;
+
+private:
+
+	virtual void BeginArray( const PropertyName& Name ) = 0;
+	virtual void EndArray() = 0;
+
+	virtual void BeginArrayObject() = 0;
+	virtual void EndArrayObject() = 0;
+
+	virtual bool WriteArrayElement( const bool Value ) = 0;
+	virtual bool WriteArrayElement( const float Value ) = 0;
+	virtual bool WriteArrayElement( const double Value ) = 0;
+
+	virtual bool WriteArrayElement( const int8_t Value ) = 0;
+	virtual bool WriteArrayElement( const int16_t Value ) = 0;
+	virtual bool WriteArrayElement( const int32_t Value ) = 0;
+	virtual bool WriteArrayElement( const int64_t Value ) = 0;
+
+	virtual bool WriteArrayElement( const uint8_t Value ) = 0;
+	virtual bool WriteArrayElement( const uint16_t Value ) = 0;
+	virtual bool WriteArrayElement( const uint32_t Value ) = 0;
+	virtual bool WriteArrayElement( const uint64_t Value ) = 0;
+
+	virtual bool WriteArrayElement( const std::string& Value ) = 0;
+};
+
+// -----------------------------------------------------------------------------
+
+} // namespace Serialisation
+} // namespace Utils
+
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------

--- a/Source/Utils/Source/Serialisation/JSON/JSONReader.cpp
+++ b/Source/Utils/Source/Serialisation/JSON/JSONReader.cpp
@@ -1,0 +1,647 @@
+// Copyright (c) 2024 Steven Frost and Orion Lyau
+
+#include <Utils/Serialisation/JSON/JSONReader.h>
+
+#include <Utils/Logging/Log.h>
+
+// -----------------------------------------------------------------------------
+
+DEFINE_LOG_CATEGORY( JSONReader, Info )
+
+// -----------------------------------------------------------------------------
+
+namespace Utils
+{
+namespace Serialisation
+{
+
+// -----------------------------------------------------------------------------
+
+JSONReader::JSONReader( const std::string& Data )
+	: JsonDocument()
+	, Stack()
+{
+	JsonDocument.Parse( Data.c_str() );
+
+	Stack.push( std::make_pair( "", rapidjson::Pointer( "" ) ) );
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadProperty( const PropertyName& Name, bool& Value )
+{
+	auto* Member = GetMember( Name );
+	if ( !Member )
+	{
+		LOG( JSONReader, Error, "Unable to resolve member '%s' in object '%s'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	if ( !Member->IsBool() )
+	{
+		LOG( JSONReader, Error, "Member '%s' in object '%s' is not of type 'bool'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = Member->GetBool();
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadProperty( const PropertyName& Name, float& Value )
+{
+	auto* Member = GetMember( Name );
+	if ( !Member )
+	{
+		LOG( JSONReader, Error, "Unable to resolve member '%s' in object '%s'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	if ( !Member->IsFloat() )
+	{
+		LOG( JSONReader, Error, "Member '%s' in object '%s' is not of type 'float'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = Member->GetFloat();
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadProperty( const PropertyName& Name, double& Value )
+{
+	auto* Member = GetMember( Name );
+	if ( !Member )
+	{
+		LOG( JSONReader, Error, "Unable to resolve member '%s' in object '%s'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	if ( !Member->IsDouble() )
+	{
+		LOG( JSONReader, Error, "Member '%s' in object '%s' is not of type 'double'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = Member->GetDouble();
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadProperty( const PropertyName& Name, int8_t& Value )
+{
+	auto* Member = GetMember( Name );
+	if ( !Member )
+	{
+		LOG( JSONReader, Error, "Unable to resolve member '%s' in object '%s'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	if ( !Member->IsInt() )
+	{
+		LOG( JSONReader, Error, "Member '%s' in object '%s' is not of type 'int'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = static_cast< int8_t >( Member->GetInt() );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadProperty( const PropertyName& Name, int16_t& Value )
+{
+	auto* Member = GetMember( Name );
+	if ( !Member )
+	{
+		LOG( JSONReader, Error, "Unable to resolve member '%s' in object '%s'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	if ( !Member->IsInt() )
+	{
+		LOG( JSONReader, Error, "Member '%s' in object '%s' is not of type 'int'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = static_cast< int16_t >( Member->GetInt() );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadProperty( const PropertyName& Name, int32_t& Value )
+{
+	auto* Member = GetMember( Name );
+	if ( !Member )
+	{
+		LOG( JSONReader, Error, "Unable to resolve member '%s' in object '%s'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	if ( !Member->IsInt() )
+	{
+		LOG( JSONReader, Error, "Member '%s' in object '%s' is not of type 'int'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = static_cast< int32_t >( Member->GetInt() );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadProperty( const PropertyName& Name, int64_t& Value )
+{
+	auto* Member = GetMember( Name );
+	if ( !Member )
+	{
+		LOG( JSONReader, Error, "Unable to resolve member '%s' in object '%s'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	if ( !Member->IsInt64() )
+	{
+		LOG( JSONReader, Error, "Member '%s' in object '%s' is not of type '64-bit int'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = static_cast< int64_t >( Member->GetInt64() );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadProperty( const PropertyName& Name, uint8_t& Value )
+{
+	auto* Member = GetMember( Name );
+	if ( !Member )
+	{
+		LOG( JSONReader, Error, "Unable to resolve member '%s' in object '%s'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	if ( !Member->IsUint() )
+	{
+		LOG( JSONReader, Error, "Member '%s' in object '%s' is not of type 'unsigned int'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = static_cast< uint8_t >( Member->GetUint() );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadProperty( const PropertyName& Name, uint16_t& Value )
+{
+	auto* Member = GetMember( Name );
+	if ( !Member )
+	{
+		LOG( JSONReader, Error, "Unable to resolve member '%s' in object '%s'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	if ( !Member->IsUint() )
+	{
+		LOG( JSONReader, Error, "Member '%s' in object '%s' is not of type 'unsigned int'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = static_cast< uint16_t >( Member->GetUint() );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadProperty( const PropertyName& Name, uint32_t& Value )
+{
+	auto* Member = GetMember( Name );
+	if ( !Member )
+	{
+		LOG( JSONReader, Error, "Unable to resolve member '%s' in object '%s'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	if ( !Member->IsUint() )
+	{
+		LOG( JSONReader, Error, "Member '%s' in object '%s' is not of type 'unsigned int'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = static_cast< uint32_t >( Member->GetUint() );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadProperty( const PropertyName& Name, uint64_t& Value )
+{
+	auto* Member = GetMember( Name );
+	if ( !Member )
+	{
+		LOG( JSONReader, Error, "Unable to resolve member '%s' in object '%s'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	if ( !Member->IsUint64() )
+	{
+		LOG( JSONReader, Error, "Member '%s' in object '%s' is not of type '64-bit unsigned int'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = static_cast< uint64_t >( Member->GetUint64() );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadProperty( const PropertyName& Name, std::string& Value )
+{
+	auto* Member = GetMember( Name );
+	if ( !Member )
+	{
+		LOG( JSONReader, Error, "Unable to resolve member '%s' in object '%s'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	if ( !Member->IsString() )
+	{
+		LOG( JSONReader, Error, "Member '%s' in object '%s' is not of type 'string'.", Name.c_str(), GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = Member->GetString();
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+void JSONReader::BeginObject( const PropertyName& Name )
+{
+	const std::string ObjectPath = GetCurrentPath().append( "/" ).append( Name );
+	Stack.push( std::make_pair( ObjectPath, rapidjson::Pointer( ObjectPath.c_str() ) ) );
+}
+
+// -----------------------------------------------------------------------------
+
+void JSONReader::EndObject()
+{
+	Stack.pop();
+}
+
+// -----------------------------------------------------------------------------
+
+size_t JSONReader::GetArraySize() const
+{
+	auto* Object = GetCurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONReader, Error, "Unable to determine the array size of an invalid object" );
+		return 0;
+	}
+
+	if ( !Object->IsArray() )
+	{
+		LOG( JSONReader, Error, "Object '%s' is not an array", GetCurrentPath().c_str() );
+		return 0;
+	}
+
+	return Object->Size();
+}
+
+// -----------------------------------------------------------------------------
+
+void JSONReader::BeginArray( const PropertyName& Name )
+{
+	const std::string Path = GetCurrentPath().append( "/" ).append( Name );
+	Stack.push( std::make_pair( Path, rapidjson::Pointer( Path.c_str() ) ) );
+}
+
+// -----------------------------------------------------------------------------
+
+void JSONReader::EndArray()
+{
+	Stack.pop();
+}
+
+// -----------------------------------------------------------------------------
+
+void JSONReader::BeginArrayObject( const size_t Index )
+{
+	const std::string Path = GetCurrentPath().append( "/" ).append( std::to_string( Index ) );
+	Stack.push( std::make_pair( Path, rapidjson::Pointer( Path.c_str() ) ) );
+}
+
+// -----------------------------------------------------------------------------
+
+void JSONReader::EndArrayObject()
+{
+	Stack.pop();
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadArrayElement( bool& Value )
+{
+	auto* Object = GetCurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONReader, Error, "Unable to read an array element from an invalid object" );
+		return false;
+	}
+
+	if ( !Object->IsBool() )
+	{
+		LOG( JSONReader, Error, "Array element '%s' is not of type 'bool'.", GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = Object->GetBool();
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadArrayElement( float& Value )
+{
+	auto* Object = GetCurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONReader, Error, "Unable to read an array element from an invalid object" );
+		return false;
+	}
+
+	if ( !Object->IsFloat() )
+	{
+		LOG( JSONReader, Error, "Array element '%s' is not of type 'float'.", GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = Object->GetFloat();
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadArrayElement( double& Value )
+{
+	auto* Object = GetCurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONReader, Error, "Unable to read an array element from an invalid object" );
+		return false;
+	}
+
+	if ( !Object->IsDouble() )
+	{
+		LOG( JSONReader, Error, "Array element '%s' is not of type 'double'.", GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = Object->GetDouble();
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadArrayElement( int8_t& Value )
+{
+	auto* Object = GetCurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONReader, Error, "Unable to read an array element from an invalid object" );
+		return false;
+	}
+
+	if ( !Object->IsInt() )
+	{
+		LOG( JSONReader, Error, "Array element '%s' is not of type 'int'.", GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = static_cast< int8_t >( Object->GetInt() );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadArrayElement( int16_t& Value )
+{
+	auto* Object = GetCurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONReader, Error, "Unable to read an array element from an invalid object" );
+		return false;
+	}
+
+	if ( !Object->IsInt() )
+	{
+		LOG( JSONReader, Error, "Array element '%s' is not of type 'int'.", GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = static_cast< int16_t >( Object->GetInt() );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadArrayElement( int32_t& Value )
+{
+	auto* Object = GetCurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONReader, Error, "Unable to read an array element from an invalid object" );
+		return false;
+	}
+
+	if ( !Object->IsInt() )
+	{
+		LOG( JSONReader, Error, "Array element '%s' is not of type 'int'.", GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = static_cast< int32_t >( Object->GetInt() );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadArrayElement( int64_t& Value )
+{
+	auto* Object = GetCurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONReader, Error, "Unable to read an array element from an invalid object" );
+		return false;
+	}
+
+	if ( !Object->IsInt64() )
+	{
+		LOG( JSONReader, Error, "Array element '%s' is not of type '64-bit int'.", GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = static_cast< int64_t >( Object->GetInt64() );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadArrayElement( uint8_t& Value )
+{
+	auto* Object = GetCurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONReader, Error, "Unable to read an array element from an invalid object" );
+		return false;
+	}
+
+	if ( !Object->IsUint() )
+	{
+		LOG( JSONReader, Error, "Array element '%s' is not of type 'unsigned int'.", GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = static_cast< uint8_t >( Object->GetUint() );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadArrayElement( uint16_t& Value )
+{
+	auto* Object = GetCurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONReader, Error, "Unable to read an array element from an invalid object" );
+		return false;
+	}
+
+	if ( !Object->IsUint() )
+	{
+		LOG( JSONReader, Error, "Array element '%s' is not of type 'unsigned int'.", GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = static_cast< uint16_t >( Object->GetUint() );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadArrayElement( uint32_t& Value )
+{
+	auto* Object = GetCurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONReader, Error, "Unable to read an array element from an invalid object" );
+		return false;
+	}
+
+	if ( !Object->IsUint() )
+	{
+		LOG( JSONReader, Error, "Array element '%s' is not of type 'unsigned int'.", GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = static_cast< uint32_t >( Object->GetUint() );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadArrayElement( uint64_t& Value )
+{
+	auto* Object = GetCurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONReader, Error, "Unable to read an array element from an invalid object" );
+		return false;
+	}
+
+	if ( !Object->IsUint64() )
+	{
+		LOG( JSONReader, Error, "Array element '%s' is not of type '64-bit unsigned int'.", GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = static_cast< uint64_t >( Object->GetUint64() );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONReader::ReadArrayElement( std::string& Value )
+{
+	auto* Object = GetCurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONReader, Error, "Unable to read an array element from an invalid object" );
+		return false;
+	}
+
+	if ( !Object->IsString() )
+	{
+		LOG( JSONReader, Error, "Array element '%s' is not of type 'string'.", GetCurrentPath().c_str() );
+		return false;
+	}
+
+	Value = Object->GetString();
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+std::string JSONReader::GetCurrentPath() const
+{
+	return Stack.top().first;
+}
+
+// -----------------------------------------------------------------------------
+
+rapidjson::Value* JSONReader::GetCurrentObject()
+{
+	auto Pointer = Stack.top().second;
+	return Pointer.Get( JsonDocument );
+}
+
+// -----------------------------------------------------------------------------
+
+const rapidjson::Value* JSONReader::GetCurrentObject() const
+{
+	auto Pointer = Stack.top().second;
+	return Pointer.Get( JsonDocument );
+}
+
+// -----------------------------------------------------------------------------
+
+rapidjson::Value* JSONReader::GetMember( const PropertyName& Name )
+{
+	auto* Object = GetCurrentObject();
+	if ( !Object )
+	{
+		return nullptr;
+	}
+
+	auto MemberIt = Object->FindMember( Name.c_str() );
+	if ( MemberIt == Object->MemberEnd() )
+	{
+		return nullptr;
+	}
+
+	return &MemberIt->value;
+}
+
+// -----------------------------------------------------------------------------
+
+} // namespace Serialisation
+} // namespace Utils
+
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------

--- a/Source/Utils/Source/Serialisation/JSON/JSONWriter.cpp
+++ b/Source/Utils/Source/Serialisation/JSON/JSONWriter.cpp
@@ -1,0 +1,616 @@
+// Copyright (c) 2024 Steven Frost and Orion Lyau
+
+#include <Utils/Serialisation/JSON/JSONWriter.h>
+
+#include <Utils/Logging/Log.h>
+
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/prettywriter.h>
+
+// -----------------------------------------------------------------------------
+
+DEFINE_LOG_CATEGORY( JSONWriter, Info )
+
+// -----------------------------------------------------------------------------
+
+namespace Utils
+{
+namespace Serialisation
+{
+
+// -----------------------------------------------------------------------------
+
+JSONWriter::JSONWriter()
+	: JsonDocument()
+	, Allocator( nullptr )
+	, Stack()
+{
+	JsonDocument.SetObject();
+	Allocator = &JsonDocument.GetAllocator();
+
+	Stack.push( std::make_pair( "", rapidjson::Pointer( "" ) ) );
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteProperty( const PropertyName& Name, const bool Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to write property '%s' in object '%s' since the current object is invalid.", Name.c_str(), CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonKey;
+	JsonKey.SetString( Name.c_str(), Name.length(), *Allocator );
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetBool( Value );
+
+	Object->AddMember( JsonKey, JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteProperty( const PropertyName& Name, const float Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to write property '%s' in object '%s' since the current object is invalid.", Name.c_str(), CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonKey;
+	JsonKey.SetString( Name.c_str(), Name.length(), *Allocator );
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetFloat( Value );
+
+	Object->AddMember( JsonKey, JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteProperty( const PropertyName& Name, const double Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to write property '%s' in object '%s' since the current object is invalid.", Name.c_str(), CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonKey;
+	JsonKey.SetString( Name.c_str(), Name.length(), *Allocator );
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetDouble( Value );
+
+	Object->AddMember( JsonKey, JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteProperty( const PropertyName& Name, const int8_t Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to write property '%s' in object '%s' since the current object is invalid.", Name.c_str(), CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonKey;
+	JsonKey.SetString( Name.c_str(), Name.length(), *Allocator );
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetInt( Value );
+
+	Object->AddMember( JsonKey, JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteProperty( const PropertyName& Name, const int16_t Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to write property '%s' in object '%s' since the current object is invalid.", Name.c_str(), CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonKey;
+	JsonKey.SetString( Name.c_str(), Name.length(), *Allocator );
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetInt( Value );
+
+	Object->AddMember( JsonKey, JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteProperty( const PropertyName& Name, const int32_t Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to write property '%s' in object '%s' since the current object is invalid.", Name.c_str(), CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonKey;
+	JsonKey.SetString( Name.c_str(), Name.length(), *Allocator );
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetInt( Value );
+
+	Object->AddMember( JsonKey, JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteProperty( const PropertyName& Name, const int64_t Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to write property '%s' in object '%s' since the current object is invalid.", Name.c_str(), CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonKey;
+	JsonKey.SetString( Name.c_str(), Name.length(), *Allocator );
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetInt64( Value );
+
+	Object->AddMember( JsonKey, JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteProperty( const PropertyName& Name, const uint8_t Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to write property '%s' in object '%s' since the current object is invalid.", Name.c_str(), CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonKey;
+	JsonKey.SetString( Name.c_str(), Name.length(), *Allocator );
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetUint( Value );
+
+	Object->AddMember( JsonKey, JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteProperty( const PropertyName& Name, const uint16_t Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to write property '%s' in object '%s' since the current object is invalid.", Name.c_str(), CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonKey;
+	JsonKey.SetString( Name.c_str(), Name.length(), *Allocator );
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetUint( Value );
+
+	Object->AddMember( JsonKey, JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteProperty( const PropertyName& Name, const uint32_t Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to write property '%s' in object '%s' since the current object is invalid.", Name.c_str(), CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonKey;
+	JsonKey.SetString( Name.c_str(), Name.length(), *Allocator );
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetUint( Value );
+
+	Object->AddMember( JsonKey, JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteProperty( const PropertyName& Name, const uint64_t Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to write property '%s' in object '%s' since the current object is invalid.", Name.c_str(), CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonKey;
+	JsonKey.SetString( Name.c_str(), Name.length(), *Allocator );
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetUint64( Value );
+
+	Object->AddMember( JsonKey, JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteProperty( const PropertyName& Name, const std::string& Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to write property '%s' in object '%s' since the current object is invalid.", Name.c_str(), CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonKey;
+	JsonKey.SetString( Name.c_str(), Name.length(), *Allocator );
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetString( Value.c_str(), Value.length(), *Allocator);
+
+	Object->AddMember( JsonKey, JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+std::string JSONWriter::ToString() const
+{
+	rapidjson::StringBuffer StringBuffer;
+	rapidjson::PrettyWriter< rapidjson::StringBuffer > Writer( StringBuffer );
+
+	JsonDocument.Accept( Writer );
+
+	return StringBuffer.GetString();
+}
+
+// -----------------------------------------------------------------------------
+
+void JSONWriter::BeginObject( const PropertyName& Name )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to write property '%s' in object '%s' since the current object is invalid.", Name.c_str(), CurrentPath().c_str() );
+		return;
+	}
+
+	rapidjson::Value JsonKey;
+	JsonKey.SetString( Name.c_str(), Name.length(), *Allocator );
+
+	Object->AddMember( JsonKey, rapidjson::Value( rapidjson::kObjectType ), *Allocator );
+
+	const std::string Path = CurrentPath().append( "/" ).append( Name );
+	Stack.push( std::make_pair( Path, rapidjson::Pointer( Path.c_str() ) ) );
+}
+
+// -----------------------------------------------------------------------------
+
+void JSONWriter::EndObject()
+{
+	Stack.pop();
+}
+
+// -----------------------------------------------------------------------------
+
+void JSONWriter::BeginArray( const PropertyName& Name )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to write property '%s' in object '%s' since the current object is invalid.", Name.c_str(), CurrentPath().c_str() );
+		return;
+	}
+
+	rapidjson::Value JsonKey;
+	JsonKey.SetString( Name.c_str(), Name.length(), *Allocator );
+
+	Object->AddMember( JsonKey, rapidjson::Value( rapidjson::kArrayType ), *Allocator );
+
+	const std::string Path = CurrentPath().append( "/" ).append( Name );
+	Stack.push( std::make_pair( Path, rapidjson::Pointer( Path.c_str() ) ) );
+}
+
+// -----------------------------------------------------------------------------
+
+void JSONWriter::EndArray()
+{
+	Stack.pop();
+}
+
+// -----------------------------------------------------------------------------
+
+void JSONWriter::BeginArrayObject()
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to add a new object in array '%s' since the current object is invalid.", CurrentPath().c_str() );
+		return;
+	}
+
+	const size_t ArraySize = Object->Size();
+
+	Object->PushBack( rapidjson::Value( rapidjson::kObjectType ), *Allocator );
+
+	const std::string Path = CurrentPath().append( "/" ).append( std::to_string( ArraySize ) );
+	Stack.push( std::make_pair( Path, rapidjson::Pointer( Path.c_str() ) ) );
+}
+
+// -----------------------------------------------------------------------------
+
+void JSONWriter::EndArrayObject()
+{
+	Stack.pop();
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteArrayElement( const bool Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to add a new element to array '%s' since the current object is invalid.", CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetBool( Value );
+
+	Object->PushBack( JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteArrayElement( const float Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to add a new element to array '%s' since the current object is invalid.", CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetFloat( Value );
+
+	Object->PushBack( JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteArrayElement( const double Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to add a new element to array '%s' since the current object is invalid.", CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetDouble( Value );
+
+	Object->PushBack( JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteArrayElement( const int8_t Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to add a new element to array '%s' since the current object is invalid.", CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetInt( Value );
+
+	Object->PushBack( JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteArrayElement( const int16_t Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to add a new element to array '%s' since the current object is invalid.", CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetInt( Value );
+
+	Object->PushBack( JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteArrayElement( const int32_t Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to add a new element to array '%s' since the current object is invalid.", CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetInt( Value );
+
+	Object->PushBack( JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteArrayElement( const int64_t Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to add a new element to array '%s' since the current object is invalid.", CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetInt64( Value );
+
+	Object->PushBack( JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteArrayElement( const uint8_t Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to add a new element to array '%s' since the current object is invalid.", CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetUint( Value );
+
+	Object->PushBack( JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteArrayElement( const uint16_t Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to add a new element to array '%s' since the current object is invalid.", CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetUint( Value );
+
+	Object->PushBack( JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteArrayElement( const uint32_t Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to add a new element to array '%s' since the current object is invalid.", CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetUint( Value );
+
+	Object->PushBack( JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteArrayElement( const uint64_t Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to add a new element to array '%s' since the current object is invalid.", CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetUint64( Value );
+
+	Object->PushBack( JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool JSONWriter::WriteArrayElement( const std::string& Value )
+{
+	auto* Object = CurrentObject();
+	if ( !Object )
+	{
+		LOG( JSONWriter, Error, "Unable to add a new element to array '%s' since the current object is invalid.", CurrentPath().c_str() );
+		return false;
+	}
+
+	rapidjson::Value JsonValue;
+	JsonValue.SetString( Value.c_str(), Value.length(), *Allocator );
+
+	Object->PushBack( JsonValue, *Allocator );
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+
+std::string JSONWriter::CurrentPath() const
+{
+	return Stack.top().first;
+}
+
+// -----------------------------------------------------------------------------
+
+rapidjson::Value* JSONWriter::CurrentObject()
+{
+	auto Pointer = Stack.top().second;
+	return Pointer.Get( JsonDocument );
+}
+
+// -----------------------------------------------------------------------------
+
+} // namespace Serialisation
+} // namespace Utils
+
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------


### PR DESCRIPTION
Serialisation and Deserialisation now occurs via Writers and Readers respectively. There's currently one concrete class backing each - the JSONWriter and JSONReader for serialisting objects to and from JSON.

Currently we only support serialisation for fundamental types, strings, arrays and classes implementing the ISerialisable interface.

There's no schema validation at the moment, that will follow on later. For now we control the JSON input so it's not critical for our first milestone.