### PR TITLE
Adjust ReadProperty so enums aren't modified if ReadProperty was unsuccessful

### DIFF
--- a/Source/Utils/Inc/Utils/Serialisation/Reader.h
+++ b/Source/Utils/Inc/Utils/Serialisation/Reader.h
@@ -14,142 +14,142 @@ namespace Utils
 namespace Serialisation
 {
 
-	// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 
-	class ISerialisable;
+class ISerialisable;
 
-	// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 
-	class Reader
+class Reader
+{
+public:
+
+	typedef std::string PropertyName;
+
+	virtual bool ReadProperty( const PropertyName& Name, bool& Value ) = 0;
+	virtual bool ReadProperty( const PropertyName& Name, float& Value ) = 0;
+	virtual bool ReadProperty( const PropertyName& Name, double& Value ) = 0;
+
+	virtual bool ReadProperty( const PropertyName& Name, int8_t& Value ) = 0;
+	virtual bool ReadProperty( const PropertyName& Name, int16_t& Value ) = 0;
+	virtual bool ReadProperty( const PropertyName& Name, int32_t& Value ) = 0;
+	virtual bool ReadProperty( const PropertyName& Name, int64_t& Value ) = 0;
+
+	virtual bool ReadProperty( const PropertyName& Name, uint8_t& Value ) = 0;
+	virtual bool ReadProperty( const PropertyName& Name, uint16_t& Value ) = 0;
+	virtual bool ReadProperty( const PropertyName& Name, uint32_t& Value ) = 0;
+	virtual bool ReadProperty( const PropertyName& Name, uint64_t& Value ) = 0;
+
+	virtual bool ReadProperty( const PropertyName& Name, std::string& Value ) = 0;
+
+	template< class TEnum >
+	auto ReadProperty( const PropertyName& Name, TEnum& Value ) -> typename std::enable_if< std::is_enum< TEnum >::value, bool >::type
 	{
-	public:
+		typedef typename std::underlying_type< TEnum >::type TEnumType;
 
-		typedef std::string PropertyName;
-
-		virtual bool ReadProperty( const PropertyName& Name, bool& Value ) = 0;
-		virtual bool ReadProperty( const PropertyName& Name, float& Value ) = 0;
-		virtual bool ReadProperty( const PropertyName& Name, double& Value ) = 0;
-
-		virtual bool ReadProperty( const PropertyName& Name, int8_t& Value ) = 0;
-		virtual bool ReadProperty( const PropertyName& Name, int16_t& Value ) = 0;
-		virtual bool ReadProperty( const PropertyName& Name, int32_t& Value ) = 0;
-		virtual bool ReadProperty( const PropertyName& Name, int64_t& Value ) = 0;
-
-		virtual bool ReadProperty( const PropertyName& Name, uint8_t& Value ) = 0;
-		virtual bool ReadProperty( const PropertyName& Name, uint16_t& Value ) = 0;
-		virtual bool ReadProperty( const PropertyName& Name, uint32_t& Value ) = 0;
-		virtual bool ReadProperty( const PropertyName& Name, uint64_t& Value ) = 0;
-
-		virtual bool ReadProperty( const PropertyName& Name, std::string& Value ) = 0;
-
-		template< class TEnum >
-		auto ReadProperty( const PropertyName& Name, TEnum& Value ) -> typename std::enable_if< std::is_enum< TEnum >::value, bool >::type
+		TEnumType EnumValue;
+		const bool Success = ReadProperty( Name, EnumValue );
+		if ( Success )
 		{
-			typedef typename std::underlying_type< TEnum >::type TEnumType;
-
-			TEnumType EnumValue;
-			const bool Success = ReadProperty( Name, EnumValue );
-			if ( Success )
-			{
-				Value = static_cast< TEnum >( EnumValue );
-			}
-
-			return Success;
+			Value = static_cast< TEnum >( EnumValue );
 		}
 
-		template< class TValue >
-		auto ReadProperty( const PropertyName& Name, TValue& Value ) -> typename std::enable_if< std::is_class< TValue >::value, bool >::type
+		return Success;
+	}
+
+	template< class TValue >
+	auto ReadProperty( const PropertyName& Name, TValue& Value ) -> typename std::enable_if< std::is_class< TValue >::value, bool >::type
+	{
+		static_assert( std::is_base_of< ISerialisable, TValue >::value, "TValue must be derived from ISerialisable" );
+
+		BeginObject( Name );
+		const bool Success = Value.Deserialise( *this );
+		EndObject();
+
+		return Success;
+	}
+
+	template< class TElement >
+	auto ReadProperty( const PropertyName& Name, std::vector< TElement >& Array ) -> typename std::enable_if< std::is_base_of< ISerialisable, TElement >::value, bool >::type
+	{
+		bool Success = true;
+
+		BeginArray( Name );
+
+		const size_t ArraySize = GetArraySize();
+
+		Array.clear();
+		Array.resize( ArraySize );
+
+		for ( size_t Index = 0; Index < ArraySize; ++Index )
 		{
-			static_assert( std::is_base_of< ISerialisable, TValue >::value, "TValue must be derived from ISerialisable" );
-
-			BeginObject( Name );
-			const bool Success = Value.Deserialise( *this );
-			EndObject();
-
-			return Success;
+			BeginArrayObject( Index );
+			Success &= Array[ Index ].Deserialise( *this );
+			EndArrayObject();
 		}
 
-		template< class TElement >
-		auto ReadProperty( const PropertyName& Name, std::vector< TElement >& Array ) -> typename std::enable_if< std::is_base_of< ISerialisable, TElement >::value, bool >::type
+		EndArray();
+
+		return Success;
+	}
+
+	template< class TElement >
+	auto ReadProperty( const PropertyName& Name, std::vector< TElement >& Array ) -> typename std::enable_if< !std::is_base_of< ISerialisable, TElement >::value, bool >::type
+	{
+		bool Success = true;
+
+		BeginArray( Name );
+
+		const size_t ArraySize = GetArraySize();
+
+		Array.clear();
+		Array.resize( ArraySize );
+
+		for ( size_t Index = 0; Index < ArraySize; ++Index )
 		{
-			bool Success = true;
-
-			BeginArray( Name );
-
-			const size_t ArraySize = GetArraySize();
-
-			Array.clear();
-			Array.resize( ArraySize );
-
-			for ( size_t Index = 0; Index < ArraySize; ++Index )
-			{
-				BeginArrayObject( Index );
-				Success &= Array[ Index ].Deserialise( *this );
-				EndArrayObject();
-			}
-
-			EndArray();
-
-			return Success;
+			BeginArrayObject( Index );
+			Success &= ReadArrayElement( Array[ Index ] );
+			EndArrayObject();
 		}
 
-		template< class TElement >
-		auto ReadProperty( const PropertyName& Name, std::vector< TElement >& Array ) -> typename std::enable_if< !std::is_base_of< ISerialisable, TElement >::value, bool >::type
-		{
-			bool Success = true;
+		EndArray();
 
-			BeginArray( Name );
+		return Success;
+	}
 
-			const size_t ArraySize = GetArraySize();
+private:
 
-			Array.clear();
-			Array.resize( ArraySize );
+	virtual void BeginObject( const PropertyName& Name ) = 0;
+	virtual void EndObject() = 0;
 
-			for ( size_t Index = 0; Index < ArraySize; ++Index )
-			{
-				BeginArrayObject( Index );
-				Success &= ReadArrayElement( Array[ Index ] );
-				EndArrayObject();
-			}
+private:
 
-			EndArray();
+	virtual size_t GetArraySize() const = 0;
 
-			return Success;
-		}
+	virtual void BeginArray( const PropertyName& Name ) = 0;
+	virtual void EndArray() = 0;
 
-	private:
+	virtual void BeginArrayObject( const size_t Index ) = 0;
+	virtual void EndArrayObject() = 0;
 
-		virtual void BeginObject( const PropertyName& Name ) = 0;
-		virtual void EndObject() = 0;
+	virtual bool ReadArrayElement( bool& Value ) = 0;
+	virtual bool ReadArrayElement( float& Value ) = 0;
+	virtual bool ReadArrayElement( double& Value ) = 0;
 
-	private:
+	virtual bool ReadArrayElement( int8_t& Value ) = 0;
+	virtual bool ReadArrayElement( int16_t& Value ) = 0;
+	virtual bool ReadArrayElement( int32_t& Value ) = 0;
+	virtual bool ReadArrayElement( int64_t& Value ) = 0;
 
-		virtual size_t GetArraySize() const = 0;
+	virtual bool ReadArrayElement( uint8_t& Value ) = 0;
+	virtual bool ReadArrayElement( uint16_t& Value ) = 0;
+	virtual bool ReadArrayElement( uint32_t& Value ) = 0;
+	virtual bool ReadArrayElement( uint64_t& Value ) = 0;
 
-		virtual void BeginArray( const PropertyName& Name ) = 0;
-		virtual void EndArray() = 0;
+	virtual bool ReadArrayElement( std::string& Value ) = 0;
+};
 
-		virtual void BeginArrayObject( const size_t Index ) = 0;
-		virtual void EndArrayObject() = 0;
-
-		virtual bool ReadArrayElement( bool& Value ) = 0;
-		virtual bool ReadArrayElement( float& Value ) = 0;
-		virtual bool ReadArrayElement( double& Value ) = 0;
-
-		virtual bool ReadArrayElement( int8_t& Value ) = 0;
-		virtual bool ReadArrayElement( int16_t& Value ) = 0;
-		virtual bool ReadArrayElement( int32_t& Value ) = 0;
-		virtual bool ReadArrayElement( int64_t& Value ) = 0;
-
-		virtual bool ReadArrayElement( uint8_t& Value ) = 0;
-		virtual bool ReadArrayElement( uint16_t& Value ) = 0;
-		virtual bool ReadArrayElement( uint32_t& Value ) = 0;
-		virtual bool ReadArrayElement( uint64_t& Value ) = 0;
-
-		virtual bool ReadArrayElement( std::string& Value ) = 0;
-	};
-
-	// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 
 } // namespace Serialisation
 } // namespace Utils

--- a/Source/Utils/Inc/Utils/Serialisation/Reader.h
+++ b/Source/Utils/Inc/Utils/Serialisation/Reader.h
@@ -14,139 +14,142 @@ namespace Utils
 namespace Serialisation
 {
 
-// -----------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------
 
-class ISerialisable;
+	class ISerialisable;
 
-// -----------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------
 
-class Reader
-{
-public:
-
-	typedef std::string PropertyName;
-
-	virtual bool ReadProperty( const PropertyName& Name, bool& Value ) = 0;
-	virtual bool ReadProperty( const PropertyName& Name, float& Value ) = 0;
-	virtual bool ReadProperty( const PropertyName& Name, double& Value ) = 0;
-
-	virtual bool ReadProperty( const PropertyName& Name, int8_t& Value ) = 0;
-	virtual bool ReadProperty( const PropertyName& Name, int16_t& Value ) = 0;
-	virtual bool ReadProperty( const PropertyName& Name, int32_t& Value ) = 0;
-	virtual bool ReadProperty( const PropertyName& Name, int64_t& Value ) = 0;
-
-	virtual bool ReadProperty( const PropertyName& Name, uint8_t& Value ) = 0;
-	virtual bool ReadProperty( const PropertyName& Name, uint16_t& Value ) = 0;
-	virtual bool ReadProperty( const PropertyName& Name, uint32_t& Value ) = 0;
-	virtual bool ReadProperty( const PropertyName& Name, uint64_t& Value ) = 0;
-
-	virtual bool ReadProperty( const PropertyName& Name, std::string& Value ) = 0;
-
-	template< class TEnum >
-	auto ReadProperty( const PropertyName& Name, TEnum& Value ) -> typename std::enable_if< std::is_enum< TEnum >::value, bool >::type
+	class Reader
 	{
-		typedef typename std::underlying_type< TEnum >::type TEnumType;
+	public:
 
-		TEnumType EnumValue;
-		const bool Success = ReadProperty( Name, EnumValue );
-		Value = static_cast< TEnum >( EnumValue );
+		typedef std::string PropertyName;
 
-		return Success;
-	}
+		virtual bool ReadProperty( const PropertyName& Name, bool& Value ) = 0;
+		virtual bool ReadProperty( const PropertyName& Name, float& Value ) = 0;
+		virtual bool ReadProperty( const PropertyName& Name, double& Value ) = 0;
 
-	template< class TValue >
-	auto ReadProperty( const PropertyName& Name, TValue& Value ) -> typename std::enable_if< std::is_class< TValue >::value, bool >::type
-	{
-		static_assert( std::is_base_of< ISerialisable, TValue >::value, "TValue must be derived from ISerialisable" );
+		virtual bool ReadProperty( const PropertyName& Name, int8_t& Value ) = 0;
+		virtual bool ReadProperty( const PropertyName& Name, int16_t& Value ) = 0;
+		virtual bool ReadProperty( const PropertyName& Name, int32_t& Value ) = 0;
+		virtual bool ReadProperty( const PropertyName& Name, int64_t& Value ) = 0;
 
-		BeginObject( Name );
-		const bool Success = Value.Deserialise( *this );
-		EndObject();
+		virtual bool ReadProperty( const PropertyName& Name, uint8_t& Value ) = 0;
+		virtual bool ReadProperty( const PropertyName& Name, uint16_t& Value ) = 0;
+		virtual bool ReadProperty( const PropertyName& Name, uint32_t& Value ) = 0;
+		virtual bool ReadProperty( const PropertyName& Name, uint64_t& Value ) = 0;
 
-		return Success;
-	}
+		virtual bool ReadProperty( const PropertyName& Name, std::string& Value ) = 0;
 
-	template< class TElement >
-	auto ReadProperty( const PropertyName& Name, std::vector< TElement >& Array ) -> typename std::enable_if< std::is_base_of< ISerialisable, TElement >::value, bool >::type
-	{
-		bool Success = true;
-
-		BeginArray( Name );
-
-		const size_t ArraySize = GetArraySize();
-
-		Array.clear();
-		Array.resize( ArraySize );
-
-		for ( size_t Index = 0; Index < ArraySize; ++Index )
+		template< class TEnum >
+		auto ReadProperty( const PropertyName& Name, TEnum& Value ) -> typename std::enable_if< std::is_enum< TEnum >::value, bool >::type
 		{
-			BeginArrayObject( Index );
-			Success &= Array[ Index ].Deserialise( *this );
-			EndArrayObject();
+			typedef typename std::underlying_type< TEnum >::type TEnumType;
+
+			TEnumType EnumValue;
+			const bool Success = ReadProperty( Name, EnumValue );
+			if ( Success )
+			{
+				Value = static_cast< TEnum >( EnumValue );
+			}
+
+			return Success;
 		}
 
-		EndArray();
-
-		return Success;
-	}
-
-	template< class TElement >
-	auto ReadProperty( const PropertyName& Name, std::vector< TElement >& Array ) -> typename std::enable_if< !std::is_base_of< ISerialisable, TElement >::value, bool >::type
-	{
-		bool Success = true;
-
-		BeginArray( Name );
-
-		const size_t ArraySize = GetArraySize();
-
-		Array.clear();
-		Array.resize( ArraySize );
-
-		for ( size_t Index = 0; Index < ArraySize; ++Index )
+		template< class TValue >
+		auto ReadProperty( const PropertyName& Name, TValue& Value ) -> typename std::enable_if< std::is_class< TValue >::value, bool >::type
 		{
-			BeginArrayObject( Index );
-			Success &= ReadArrayElement( Array[ Index ] );
-			EndArrayObject();
+			static_assert( std::is_base_of< ISerialisable, TValue >::value, "TValue must be derived from ISerialisable" );
+
+			BeginObject( Name );
+			const bool Success = Value.Deserialise( *this );
+			EndObject();
+
+			return Success;
 		}
 
-		EndArray();
+		template< class TElement >
+		auto ReadProperty( const PropertyName& Name, std::vector< TElement >& Array ) -> typename std::enable_if< std::is_base_of< ISerialisable, TElement >::value, bool >::type
+		{
+			bool Success = true;
 
-		return Success;
-	}
+			BeginArray( Name );
 
-private:
+			const size_t ArraySize = GetArraySize();
 
-	virtual void BeginObject( const PropertyName& Name ) = 0;
-	virtual void EndObject() = 0;
+			Array.clear();
+			Array.resize( ArraySize );
 
-private:
+			for ( size_t Index = 0; Index < ArraySize; ++Index )
+			{
+				BeginArrayObject( Index );
+				Success &= Array[ Index ].Deserialise( *this );
+				EndArrayObject();
+			}
 
-	virtual size_t GetArraySize() const = 0;
+			EndArray();
 
-	virtual void BeginArray( const PropertyName& Name ) = 0;
-	virtual void EndArray() = 0;
+			return Success;
+		}
 
-	virtual void BeginArrayObject( const size_t Index ) = 0;
-	virtual void EndArrayObject() = 0;
+		template< class TElement >
+		auto ReadProperty( const PropertyName& Name, std::vector< TElement >& Array ) -> typename std::enable_if< !std::is_base_of< ISerialisable, TElement >::value, bool >::type
+		{
+			bool Success = true;
 
-	virtual bool ReadArrayElement( bool& Value ) = 0;
-	virtual bool ReadArrayElement( float& Value ) = 0;
-	virtual bool ReadArrayElement( double& Value ) = 0;
+			BeginArray( Name );
 
-	virtual bool ReadArrayElement( int8_t& Value ) = 0;
-	virtual bool ReadArrayElement( int16_t& Value ) = 0;
-	virtual bool ReadArrayElement( int32_t& Value ) = 0;
-	virtual bool ReadArrayElement( int64_t& Value ) = 0;
+			const size_t ArraySize = GetArraySize();
 
-	virtual bool ReadArrayElement( uint8_t& Value ) = 0;
-	virtual bool ReadArrayElement( uint16_t& Value ) = 0;
-	virtual bool ReadArrayElement( uint32_t& Value ) = 0;
-	virtual bool ReadArrayElement( uint64_t& Value ) = 0;
+			Array.clear();
+			Array.resize( ArraySize );
 
-	virtual bool ReadArrayElement( std::string& Value ) = 0;
-};
+			for ( size_t Index = 0; Index < ArraySize; ++Index )
+			{
+				BeginArrayObject( Index );
+				Success &= ReadArrayElement( Array[ Index ] );
+				EndArrayObject();
+			}
 
-// -----------------------------------------------------------------------------
+			EndArray();
+
+			return Success;
+		}
+
+	private:
+
+		virtual void BeginObject( const PropertyName& Name ) = 0;
+		virtual void EndObject() = 0;
+
+	private:
+
+		virtual size_t GetArraySize() const = 0;
+
+		virtual void BeginArray( const PropertyName& Name ) = 0;
+		virtual void EndArray() = 0;
+
+		virtual void BeginArrayObject( const size_t Index ) = 0;
+		virtual void EndArrayObject() = 0;
+
+		virtual bool ReadArrayElement( bool& Value ) = 0;
+		virtual bool ReadArrayElement( float& Value ) = 0;
+		virtual bool ReadArrayElement( double& Value ) = 0;
+
+		virtual bool ReadArrayElement( int8_t& Value ) = 0;
+		virtual bool ReadArrayElement( int16_t& Value ) = 0;
+		virtual bool ReadArrayElement( int32_t& Value ) = 0;
+		virtual bool ReadArrayElement( int64_t& Value ) = 0;
+
+		virtual bool ReadArrayElement( uint8_t& Value ) = 0;
+		virtual bool ReadArrayElement( uint16_t& Value ) = 0;
+		virtual bool ReadArrayElement( uint32_t& Value ) = 0;
+		virtual bool ReadArrayElement( uint64_t& Value ) = 0;
+
+		virtual bool ReadArrayElement( std::string& Value ) = 0;
+	};
+
+	// -----------------------------------------------------------------------------
 
 } // namespace Serialisation
 } // namespace Utils


### PR DESCRIPTION
Just noticed this earlier -- I think it probably makes sense to only set `Value` when the read was successful?

(Otherwise if `ReadProperty` fails, `EnumValue` might be in an indeterminate state depending on how it failed, which would then get carried over to `Value`.  Probably safer to leave the caller's `Value` unaffected if the read wasn't successful?)