### PR TITLE
Update EventDispatcher to use JSONWriter in FireEvent

### DIFF
--- a/Source/Utils/Inc/Utils/Event/EventDispatcher.h
+++ b/Source/Utils/Inc/Utils/Event/EventDispatcher.h
@@ -5,6 +5,7 @@
 #include <Utils/Event/Event.h>
 #include <Utils/Event/EventHandle.h>
 #include <Utils/Serialisation/JSON/JSONReader.h>
+#include <Utils/Serialisation/JSON/JSONWriter.h>
 #include <Utils/WASM/Macros.h>
 
 #include <functional>
@@ -31,7 +32,9 @@ public:
 	{
 		static_assert( std::is_base_of< Utils::Event, TEvent >::value, "TEvent must be derived from Event" );
 
-		FireEvent( EventTraits< TEvent >::Id, Event.Serialise() );
+		Utils::Serialisation::JSONWriter Writer;
+		Event.Serialise( Writer );
+		FireEvent( EventTraits< TEvent >::Id, Writer.ToString() );
 	}
 
 	template< class TEvent >


### PR DESCRIPTION
In PR #22 `ISerialisable` was updated to use a `Writer` or `Reader` by reference when serializing and deserializing (rather than using `std::string` directly).  While the `EventDispatcher` was updated to use `Utils::Serialisation::JSONReader` for deserialization (in `RegisterEventListener`), serialization (in `FireEvent`) was not updated to match the new `ISerialisable` interface.

This PR is to make `FireEvent` work in accordance with the aforementioned changes to `ISerialisable`, using a `Utils::Serialisation::JSONWriter` to mirror the usage of `Utils::Serialisation::JSONReader` in `RegisterEventListener`.