### PR TITLE
Updated project for MSFS 2024 compatibility

### DIFF
--- a/Packages/PackageDefinitions/meridian-simcache.xml
+++ b/Packages/PackageDefinitions/meridian-simcache.xml
@@ -12,7 +12,7 @@
 	</Flags>
 	<AssetGroups>
 		<AssetGroup Name="ContentInfo">
-			<Type>ContentInfo</Type>
+			<Type Version="0">ContentInfo</Type>
 			<Flags>
 				<FSXCompatibility>false</FSXCompatibility>
 			</Flags>
@@ -20,7 +20,7 @@
 			<OutputDir>ContentInfo\meridian-simcache\</OutputDir>
 		</AssetGroup>
 		<AssetGroup Name="Data">
-			<Type>Copy</Type>
+			<Type Version="0">Copy</Type>
 			<Flags>
 				<FSXCompatibility>false</FSXCompatibility>
 			</Flags>
@@ -28,7 +28,7 @@
 			<OutputDir>Data\</OutputDir>
 		</AssetGroup>
 		<AssetGroup Name="InGamePanelSources">
-			<Type>Copy</Type>
+			<Type Version="0">Copy</Type>
 			<Flags>
 				<FSXCompatibility>false</FSXCompatibility>
 			</Flags>
@@ -36,7 +36,7 @@
 			<OutputDir>html_ui\</OutputDir>
 		</AssetGroup>
 		<AssetGroup Name="InGamePanelDefinitions">
-			<Type>SPB</Type>
+			<Type Version="0">SPB</Type>
 			<Flags>
 				<FSXCompatibility>false</FSXCompatibility>
 			</Flags>
@@ -44,7 +44,7 @@
 			<OutputDir>InGamePanels\</OutputDir>
 		</AssetGroup>
 		<AssetGroup Name="Module">
-			<Type>Copy</Type>
+			<Type Version="0">Copy</Type>
 			<Flags>
 				<FSXCompatibility>false</FSXCompatibility>
 			</Flags>
@@ -52,7 +52,7 @@
 			<OutputDir>modules\</OutputDir>
 		</AssetGroup>
 		<AssetGroup Name="SimObject">
-			<Type>SimObject</Type>
+			<Type Version="1">SimObject</Type>
 			<Flags>
 				<FSXCompatibility>false</FSXCompatibility>
 			</Flags>

--- a/Scripts/2020/BuildAllPackages.bat
+++ b/Scripts/2020/BuildAllPackages.bat
@@ -4,11 +4,11 @@ set PackageToolLocation=%MSFS_SDK%Tools\bin\fspackagetool.exe
 set StoreUserConfigLocation=%LOCALAPPDATA%\Packages\Microsoft.FlightSimulator_8wekyb3d8bbwe\LocalCache\UserCfg.opt
 set SteamUserConfigLocation=%APPDATA%\Microsoft Flight Simulator\UserCfg.opt
 
-cd ..\Packages\
+cd ..\..\Packages\
 
 if not exist "%PackageToolLocation%" (
-    echo "Unable to locate fspackagetool.exe"
-    goto Exit
+	echo "Unable to locate fspackagetool.exe"
+	goto Exit
 )
 
 if exist "%StoreUserConfigLocation%" (

--- a/Scripts/2020/CopyBuiltPackagesToCommunityFolder.bat
+++ b/Scripts/2020/CopyBuiltPackagesToCommunityFolder.bat
@@ -7,7 +7,7 @@ if exist "%StoreUserConfigLocation%" (
 	set UserConfigFileLocation=%StoreUserConfigLocation%
 	goto CopyPackage
 ) else (
-	if exist "%SteamUserConfigLocation%" (	
+	if exist "%SteamUserConfigLocation%" (
 		set UserConfigFileLocation=%SteamUserConfigLocation%
 		goto CopyPackage
 	) else (
@@ -19,12 +19,12 @@ if exist "%StoreUserConfigLocation%" (
 
 :CopyPackage
 for /f "tokens=1,*" %%a in ( 'findstr /C:"InstalledPackagesPath" "%UserConfigFileLocation%"' ) do (
-    set PackagesDirectory=%%b
+	set PackagesDirectory=%%b
 )
 set PackagesDirectory=%PackagesDirectory:"=%
 set CommunityDirectory=%PackagesDirectory%\Community
 
-cd ..\Packages\
+cd ..\..\Packages\
 
 set SourcePackageDirectory=%cd%\Built\Packages\meridian-simcache
 set DestinationPackageDirectory=%CommunityDirectory%\meridian-simcache

--- a/Scripts/2024/BuildAllPackages.bat
+++ b/Scripts/2024/BuildAllPackages.bat
@@ -1,0 +1,36 @@
+@echo off
+
+set PackageToolLocation=%MSFS2024_SDK%Tools\bin\fspackagetool.exe
+set StoreUserConfigLocation=%LOCALAPPDATA%\Packages\Microsoft.Limitless_8wekyb3d8bbwe\LocalCache\UserCfg.opt
+set SteamUserConfigLocation=%APPDATA%\Microsoft Flight Simulator\UserCfg.opt
+
+cd ..\..\Packages\
+
+if not exist "%PackageToolLocation%" (
+	echo "Unable to locate fspackagetool.exe"
+	goto Exit
+)
+
+if exist "%StoreUserConfigLocation%" (
+	goto Store
+) else (
+	if exist "%SteamUserConfigLocation%" (	
+		goto Steam
+	) else (
+		echo "Failed to locate UserCfg.opt"
+		goto Exit
+	)
+)
+
+
+:Store
+start "" "%PackageToolLocation%" ".\SimCache.xml" -nopause
+goto Exit
+
+
+:Steam
+start "" "%PackageToolLocation%" ".\SimCache.xml" -forcesteam
+goto Exit
+
+
+:Exit

--- a/Scripts/2024/BuildAllPackages.bat
+++ b/Scripts/2024/BuildAllPackages.bat
@@ -2,7 +2,7 @@
 
 set PackageToolLocation=%MSFS2024_SDK%Tools\bin\fspackagetool.exe
 set StoreUserConfigLocation=%LOCALAPPDATA%\Packages\Microsoft.Limitless_8wekyb3d8bbwe\LocalCache\UserCfg.opt
-set SteamUserConfigLocation=%APPDATA%\Microsoft Flight Simulator\UserCfg.opt
+set SteamUserConfigLocation=%APPDATA%\Microsoft Flight Simulator 2024\UserCfg.opt
 
 cd ..\..\Packages\
 

--- a/Scripts/2024/CopyBuiltPackagesToCommunityFolder.bat
+++ b/Scripts/2024/CopyBuiltPackagesToCommunityFolder.bat
@@ -1,0 +1,39 @@
+@echo off
+
+set StoreUserConfigLocation=%LOCALAPPDATA%\Packages\Microsoft.Limitless_8wekyb3d8bbwe\LocalCache\UserCfg.opt
+set SteamUserConfigLocation=%APPDATA%\Microsoft Flight Simulator\UserCfg.opt
+
+if exist "%StoreUserConfigLocation%" (
+	set UserConfigFileLocation=%StoreUserConfigLocation%
+	goto CopyPackage
+) else (
+	if exist "%SteamUserConfigLocation%" (
+		set UserConfigFileLocation=%SteamUserConfigLocation%
+		goto CopyPackage
+	) else (
+		echo "Failed to locate UserCfg.opt"
+		goto Exit
+	)
+)
+
+
+:CopyPackage
+for /f "tokens=1,*" %%a in ( 'findstr /C:"InstalledPackagesPath" "%UserConfigFileLocation%"' ) do (
+	set PackagesDirectory=%%b
+)
+set PackagesDirectory=%PackagesDirectory:"=%
+set CommunityDirectory=%PackagesDirectory%\Community
+
+cd ..\..\Packages\
+
+set SourcePackageDirectory=%cd%\Built\Packages\meridian-simcache
+set DestinationPackageDirectory=%CommunityDirectory%\meridian-simcache
+
+if exist "%SourcePackageDirectory%" (
+	if exist "%DestinationPackageDirectory%" (
+		rmdir /s /q "%DestinationPackageDirectory%"
+	)
+	robocopy "%SourcePackageDirectory%" "%DestinationPackageDirectory%" /E
+)
+
+:Exit

--- a/Scripts/2024/CopyBuiltPackagesToCommunityFolder.bat
+++ b/Scripts/2024/CopyBuiltPackagesToCommunityFolder.bat
@@ -1,7 +1,7 @@
 @echo off
 
 set StoreUserConfigLocation=%LOCALAPPDATA%\Packages\Microsoft.Limitless_8wekyb3d8bbwe\LocalCache\UserCfg.opt
-set SteamUserConfigLocation=%APPDATA%\Microsoft Flight Simulator\UserCfg.opt
+set SteamUserConfigLocation=%APPDATA%\Microsoft Flight Simulator 2024\UserCfg.opt
 
 if exist "%StoreUserConfigLocation%" (
 	set UserConfigFileLocation=%StoreUserConfigLocation%


### PR DESCRIPTION
Loaded the SimCache.xml project file in MSFS and accepted the changes. Only the SimObject asset group really changed, being updated to version 1. I assume version 0 is MSFS 2020. The package did build successfully without upgrading the project file but warnings were output, this change resolves those.

The project still builds in MSFS 2020 with the new MSFS 2024 metadata.

I also added MSFS 2024 versions of the scripts for generating & copying the packages. We could probably combine the scripts and have both projects get built but I didn't really think it was worth it right now since we haven't really discussed whether we plan to support both or just MSFS 2024. If we use the new EFB I imagine we'll have to build an MSFS 2020 specific UI to do the same job.