### PR TITLE
Improve cache tracker data flow

### DIFF
--- a/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.js
+++ b/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.js
@@ -1,7 +1,7 @@
 //-----------------------------------------------------------------------------
 
-// matches SimCache\Source\SimCacheModule\Source\Core\TrackerState.h
-const TrackerState = Object.freeze({
+// matches SimCache\Source\SimCacheModule\Source\Core\RangeAnnulus.h
+const RangeAnnulus = Object.freeze({
     Annulus1: 0, // innermost
     Annulus2: 1,
     Annulus3: 2,
@@ -39,18 +39,31 @@ class SimCachePanel extends UIElement {
     }
 
     onSubsystemsInitialized() {
-        this.CommBusListener.on("SimCache.TrackerStateUpdatedEvent", this.onTrackerStateUpdatedEvent.bind(this));
-        this.CommBusListener.on("SimCache.CacheFoundEvent", this.onCacheFoundEvent.bind(this));
-        this.CommBusListener.callWasm("SimCache.TrackerLoadedEvent", "");
+        this.CommBusListener.on("SimCache.UITrackedCacheChangedEvent", this.onTrackedCacheChangedEvent.bind(this));
+        this.CommBusListener.on("SimCache.UIRangeAnnulusChangedEvent", this.onRangeAnnulusChangedEvent.bind(this));
+        this.CommBusListener.on("SimCache.UICacheFoundEvent", this.onCacheFoundEvent.bind(this));
+        this.CommBusListener.callWasm("SimCache.UITrackerLoadedEvent", "");
     }
 
-    onTrackerStateUpdatedEvent(eventData) {
+    onTrackedCacheChangedEvent(eventData) {
         if (this.m_timeoutID !== null) {
             this.cancelPendingClose();
         }
         const data = JSON.parse(eventData);
-        this.updateUIElements(data.id, data.state);
+        this.updateCacheTitle(data.name);
+        this.updateCacheRange(data.annulus);
         this.makeVisible();
+    }
+
+    onRangeAnnulusChangedEvent(eventData) {
+        if (this.m_timeoutID !== null) {
+            // if we somehow get an event while we're waiting for the timeout, just ingore the event
+            // (the timeout only gets set after the cache is collected, and if there hasn't been a new tracked cache,
+            //  it doesn't make sense to replace the "Cache collected" text)
+            return;
+        }
+        const data = JSON.parse(eventData);
+        this.updateCacheRange(data.annulus);
     }
 
     cancelPendingClose() {
@@ -71,11 +84,6 @@ class SimCachePanel extends UIElement {
         }, 5000);
     }
 
-    updateUIElements(title, trackerStateAnnulus) {
-        this.updateCacheTitle(title);
-        this.updateCacheRange(trackerStateAnnulus);
-    }
-
     makeVisible() {
         // ensure the panel is visible (since display-none is set in the html upon load)
         // (this is done to prevent the panel from appearing before it's fully initialized)
@@ -86,40 +94,40 @@ class SimCachePanel extends UIElement {
         this.m_titleElement.innerText = title;
     }
 
-    updateCacheRange(trackerStateAnnulus) {
-        const piecewiseRange = this.getPiecewiseRange(trackerStateAnnulus);
-        this.m_subtitleElement.innerText = this.getSubtitle(piecewiseRange);
-        this.m_annulusElement.setAttributeNS(null, "r", this.getAnnulusInnerRadius(trackerStateAnnulus));
+    updateCacheRange(rangeAnnulus) {
+        const rangeNauticalMiles = this.getRangeNauticalMiles(rangeAnnulus);
+        this.m_subtitleElement.innerText = this.getSubtitle(rangeNauticalMiles);
+        this.m_annulusElement.setAttributeNS(null, "r", this.getAnnulusInnerRadius(rangeAnnulus));
     }
 
-    getSubtitle(piecewiseRange) {
-        return piecewiseRange !== null ? `Less than ${piecewiseRange} nm away` : "Out of range";
+    getSubtitle(rangeNauticalMiles) {
+        return rangeNauticalMiles !== null ? `Less than ${rangeNauticalMiles} NM away` : "Out of range";
     }
 
-    getPiecewiseRange(trackerStateAnnulus) {
-        switch (trackerStateAnnulus) {
-            case TrackerState.Annulus1:
+    getRangeNauticalMiles(rangeAnnulus) {
+        switch (rangeAnnulus) {
+            case RangeAnnulus.Annulus1:
                 return 2;
-            case TrackerState.Annulus2:
+            case RangeAnnulus.Annulus2:
                 return 5;
-            case TrackerState.Annulus3:
+            case RangeAnnulus.Annulus3:
                 return 10;
-            case TrackerState.Annulus4:
+            case RangeAnnulus.Annulus4:
                 return 25;
             default:
                 return null;
         }
     }
 
-    getAnnulusInnerRadius(trackerStateAnnulus) {
-        switch (trackerStateAnnulus) {
-            case TrackerState.Annulus1:
+    getAnnulusInnerRadius(rangeAnnulus) {
+        switch (rangeAnnulus) {
+            case RangeAnnulus.Annulus1:
                 return 0;
-            case TrackerState.Annulus2:
+            case RangeAnnulus.Annulus2:
                 return 22;
-            case TrackerState.Annulus3:
+            case RangeAnnulus.Annulus3:
                 return 31;
-            case TrackerState.Annulus4:
+            case RangeAnnulus.Annulus4:
                 return 40;
             default:
                 return 49;

--- a/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.js
+++ b/Packages/PackageSources/meridian-simcache/html_ui/InGamePanels/SimCache/SimCache.js
@@ -39,13 +39,13 @@ class SimCachePanel extends UIElement {
     }
 
     onSubsystemsInitialized() {
-        this.CommBusListener.on("SimCache.UITrackedCacheChangedEvent", this.onTrackedCacheChangedEvent.bind(this));
+        this.CommBusListener.on("SimCache.UITrackerDataUpdateEvent", this.onTrackerDataUpdateEvent.bind(this));
         this.CommBusListener.on("SimCache.UIRangeAnnulusChangedEvent", this.onRangeAnnulusChangedEvent.bind(this));
         this.CommBusListener.on("SimCache.UICacheFoundEvent", this.onCacheFoundEvent.bind(this));
         this.CommBusListener.callWasm("SimCache.UITrackerLoadedEvent", "");
     }
 
-    onTrackedCacheChangedEvent(eventData) {
+    onTrackerDataUpdateEvent(eventData) {
         if (this.m_timeoutID !== null) {
             this.cancelPendingClose();
         }

--- a/Source/SimCacheModule/Build/SimCacheModule.vcxproj
+++ b/Source/SimCacheModule/Build/SimCacheModule.vcxproj
@@ -51,7 +51,7 @@
     <ClInclude Include="..\Source\Events\TrackedCacheChangedEvent.h" />
     <ClInclude Include="..\Source\Events\UICacheFoundEvent.h" />
     <ClInclude Include="..\Source\Events\UIRangeAnnulusChangedEvent.h" />
-    <ClInclude Include="..\Source\Events\UITrackedCacheChangedEvent.h" />
+    <ClInclude Include="..\Source\Events\UITrackerDataUpdateEvent.h" />
     <ClInclude Include="..\Source\Events\UITrackerLoadedEvent.h" />
     <ClInclude Include="..\Source\Module\SimCacheModule.h" />
     <ClInclude Include="..\Source\Subsystems\AircraftTracker\AircraftTracker.h" />

--- a/Source/SimCacheModule/Build/SimCacheModule.vcxproj
+++ b/Source/SimCacheModule/Build/SimCacheModule.vcxproj
@@ -43,13 +43,16 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\Source\Core\CacheDefinitionCollection.h" />
-    <ClInclude Include="..\Source\Core\TrackerState.h" />
+    <ClInclude Include="..\Source\Core\RangeAnnulus.h" />
     <ClInclude Include="..\Source\Events\CacheAlertRangeEnteredEvent.h" />
-    <ClInclude Include="..\Source\Events\TrackerStateUpdatedEvent.h" />
+    <ClInclude Include="..\Source\Events\RangeAnnulusChangedEvent.h" />
     <ClInclude Include="..\Source\Events\AircraftPositionUpdatedEvent.h" />
     <ClInclude Include="..\Source\Events\CacheFoundEvent.h" />
     <ClInclude Include="..\Source\Events\TrackedCacheChangedEvent.h" />
-    <ClInclude Include="..\Source\Events\TrackerLoadedEvent.h" />
+    <ClInclude Include="..\Source\Events\UICacheFoundEvent.h" />
+    <ClInclude Include="..\Source\Events\UIRangeAnnulusChangedEvent.h" />
+    <ClInclude Include="..\Source\Events\UITrackedCacheChangedEvent.h" />
+    <ClInclude Include="..\Source\Events\UITrackerLoadedEvent.h" />
     <ClInclude Include="..\Source\Module\SimCacheModule.h" />
     <ClInclude Include="..\Source\Subsystems\AircraftTracker\AircraftTracker.h" />
     <ClInclude Include="..\Source\Subsystems\CacheDataStore\CacheDataStore.h" />

--- a/Source/SimCacheModule/Build/SimCacheModule.vcxproj.filters
+++ b/Source/SimCacheModule/Build/SimCacheModule.vcxproj.filters
@@ -113,7 +113,7 @@
     <ClInclude Include="..\Source\Events\UIRangeAnnulusChangedEvent.h">
       <Filter>Source\Events</Filter>
     </ClInclude>
-    <ClInclude Include="..\Source\Events\UITrackedCacheChangedEvent.h">
+    <ClInclude Include="..\Source\Events\UITrackerDataUpdateEvent.h">
       <Filter>Source\Events</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Source/SimCacheModule/Build/SimCacheModule.vcxproj.filters
+++ b/Source/SimCacheModule/Build/SimCacheModule.vcxproj.filters
@@ -71,7 +71,7 @@
     <ClInclude Include="..\Source\ViewModels\ViewModel.h">
       <Filter>Source\ViewModels</Filter>
     </ClInclude>
-    <ClInclude Include="..\Source\Events\TrackerLoadedEvent.h">
+    <ClInclude Include="..\Source\Events\UITrackerLoadedEvent.h">
       <Filter>Source\Events</Filter>
     </ClInclude>
     <ClInclude Include="..\Source\Core\CacheDefinitionCollection.h">
@@ -80,10 +80,10 @@
     <ClInclude Include="..\Source\Subsystems\CacheTracker\CacheTracker.h">
       <Filter>Source\Subsystems\CacheTracker</Filter>
     </ClInclude>
-    <ClInclude Include="..\Source\Core\TrackerState.h">
+    <ClInclude Include="..\Source\Core\RangeAnnulus.h">
       <Filter>Source\Core</Filter>
     </ClInclude>
-    <ClInclude Include="..\Source\Events\TrackerStateUpdatedEvent.h">
+    <ClInclude Include="..\Source\Events\RangeAnnulusChangedEvent.h">
       <Filter>Source\Events</Filter>
     </ClInclude>
     <ClInclude Include="..\Source\Events\CacheAlertRangeEnteredEvent.h">
@@ -106,6 +106,15 @@
     </ClInclude>
     <ClInclude Include="..\Source\Subsystems\CacheDataStore\CacheDataStore.h">
       <Filter>Source\Subsystems\CacheDataStore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Source\Events\UICacheFoundEvent.h">
+      <Filter>Source\Events</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Source\Events\UIRangeAnnulusChangedEvent.h">
+      <Filter>Source\Events</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Source\Events\UITrackedCacheChangedEvent.h">
+      <Filter>Source\Events</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Source/SimCacheModule/Source/Core/RangeAnnulus.h
+++ b/Source/SimCacheModule/Source/Core/RangeAnnulus.h
@@ -4,7 +4,7 @@
 
 // -----------------------------------------------------------------------------
 
-enum class TrackerState : uint8_t
+enum class RangeAnnulus : uint8_t
 {
 	Annulus1, // innermost
 	Annulus2,

--- a/Source/SimCacheModule/Source/Events/RangeAnnulusChangedEvent.h
+++ b/Source/SimCacheModule/Source/Events/RangeAnnulusChangedEvent.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2024 Steven Frost and Orion Lyau
+
+#pragma once
+
+#include "Core/CacheDefinitionCollection.h"
+#include "Core/RangeAnnulus.h"
+
+#include <Utils/Event/Event.h>
+
+// -----------------------------------------------------------------------------
+
+class RangeAnnulusChangedEvent
+	: public Utils::Event
+{
+public:
+	RangeAnnulusChangedEvent() = default;
+
+	RangeAnnulusChangedEvent( const CacheId& Id, const RangeAnnulus& Annulus )
+		: Id( Id )
+		, Annulus( Annulus )
+	{}
+
+public: // ISerialisable
+
+	virtual bool Serialise( Utils::Serialisation::Writer& Writer ) const override
+	{
+		bool Success = true;
+
+		Success &= Writer.WriteProperty( "id", Id );
+		Success &= Writer.WriteProperty( "annulus", Annulus );
+
+		return Success;
+	}
+
+	virtual bool Deserialise( Utils::Serialisation::Reader& Reader ) override
+	{
+		bool Success = true;
+
+		Success &= Reader.ReadProperty( "id", Id );
+		Success &= Reader.ReadProperty( "annulus", Annulus );
+
+		return Success;
+	}
+
+public:
+
+	CacheId Id;
+	RangeAnnulus Annulus;
+};
+
+// -----------------------------------------------------------------------------
+
+template<>
+struct Utils::EventTraits< RangeAnnulusChangedEvent >
+{
+	static constexpr char* Id = "SimCache.RangeAnnulusChangedEvent";
+};
+
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------

--- a/Source/SimCacheModule/Source/Events/UICacheFoundEvent.h
+++ b/Source/SimCacheModule/Source/Events/UICacheFoundEvent.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2024 Steven Frost and Orion Lyau
+
+#pragma once
+
+#include <Utils/Event/Event.h>
+
+// -----------------------------------------------------------------------------
+
+class UICacheFoundEvent
+	: public Utils::Event
+{
+public:
+
+	virtual bool Serialise( Utils::Serialisation::Writer& Writer ) const override final { return true; }
+	virtual bool Deserialise( Utils::Serialisation::Reader& Reader ) override final { return true; }
+};
+
+// -----------------------------------------------------------------------------
+
+template<>
+struct Utils::EventTraits< UICacheFoundEvent >
+{
+	static constexpr char* Id = "SimCache.UICacheFoundEvent";
+};
+
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------

--- a/Source/SimCacheModule/Source/Events/UIRangeAnnulusChangedEvent.h
+++ b/Source/SimCacheModule/Source/Events/UIRangeAnnulusChangedEvent.h
@@ -2,23 +2,24 @@
 
 #pragma once
 
-#include "Core/CacheDefinitionCollection.h"
-#include "Core/TrackerState.h"
+#include "Core/RangeAnnulus.h"
+
+#include "Events/RangeAnnulusChangedEvent.h"
 
 #include <Utils/Event/Event.h>
 
 // -----------------------------------------------------------------------------
 
-class TrackerStateUpdatedEvent
+class UIRangeAnnulusChangedEvent
 	: public Utils::Event
 {
 public:
-	TrackerStateUpdatedEvent() = default;
+	UIRangeAnnulusChangedEvent() = default;
 
-	TrackerStateUpdatedEvent( const CacheId& Id, const TrackerState& State )
-		: Id( Id )
-		, State( State )
-	{}
+	UIRangeAnnulusChangedEvent( const RangeAnnulusChangedEvent& Event )
+		: Annulus( Event.Annulus )
+	{
+	}
 
 public: // ISerialisable
 
@@ -26,8 +27,7 @@ public: // ISerialisable
 	{
 		bool Success = true;
 
-		Success &= Writer.WriteProperty( "id", Id );
-		Success &= Writer.WriteProperty( "state", State );
+		Success &= Writer.WriteProperty( "annulus", Annulus );
 
 		return Success;
 	}
@@ -36,24 +36,22 @@ public: // ISerialisable
 	{
 		bool Success = true;
 
-		Success &= Reader.ReadProperty( "id", Id );
-		Success &= Reader.ReadProperty( "state", State );
+		Success &= Reader.ReadProperty( "annulus", Annulus );
 
 		return Success;
 	}
 
 public:
 
-	CacheId Id;
-	TrackerState State;
+	RangeAnnulus Annulus;
 };
 
 // -----------------------------------------------------------------------------
 
 template<>
-struct Utils::EventTraits< TrackerStateUpdatedEvent >
+struct Utils::EventTraits< UIRangeAnnulusChangedEvent >
 {
-	static constexpr char* Id = "SimCache.TrackerStateUpdatedEvent";
+	static constexpr char* Id = "SimCache.UIRangeAnnulusChangedEvent";
 };
 
 // -----------------------------------------------------------------------------

--- a/Source/SimCacheModule/Source/Events/UITrackedCacheChangedEvent.h
+++ b/Source/SimCacheModule/Source/Events/UITrackedCacheChangedEvent.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2024 Steven Frost and Orion Lyau
+
+#pragma once
+
+#include "Core/RangeAnnulus.h"
+
+#include <Utils/Event/Event.h>
+
+// -----------------------------------------------------------------------------
+
+class UITrackedCacheChangedEvent
+	: public Utils::Event
+{
+public:
+
+	UITrackedCacheChangedEvent() = default;
+
+	UITrackedCacheChangedEvent( const std::string& CacheName, const RangeAnnulus Annulus )
+		: CacheName( CacheName )
+		, Annulus( Annulus )
+	{
+	}
+
+public: // ISerialisable
+
+	virtual bool Serialise( Utils::Serialisation::Writer& Writer ) const override final
+	{
+		bool Success = true;
+
+		Success &= Writer.WriteProperty( "name", CacheName );
+		Success &= Writer.WriteProperty( "annulus", Annulus );
+
+		return Success;
+	}
+
+	virtual bool Deserialise( Utils::Serialisation::Reader& Reader ) override final
+	{
+		bool Success = true;
+
+		Success &= Reader.ReadProperty( "name", CacheName );
+		Success &= Reader.ReadProperty( "annulus", Annulus );
+
+		return Success;
+	}
+
+public:
+
+	std::string CacheName;
+	RangeAnnulus Annulus;
+};
+
+// -----------------------------------------------------------------------------
+
+template<>
+struct Utils::EventTraits< UITrackedCacheChangedEvent >
+{
+	static constexpr char* Id = "SimCache.UITrackedCacheChangedEvent";
+};
+
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------

--- a/Source/SimCacheModule/Source/Events/UITrackerDataUpdateEvent.h
+++ b/Source/SimCacheModule/Source/Events/UITrackerDataUpdateEvent.h
@@ -8,14 +8,14 @@
 
 // -----------------------------------------------------------------------------
 
-class UITrackedCacheChangedEvent
+class UITrackerDataUpdateEvent
 	: public Utils::Event
 {
 public:
 
-	UITrackedCacheChangedEvent() = default;
+	UITrackerDataUpdateEvent() = default;
 
-	UITrackedCacheChangedEvent( const std::string& CacheName, const RangeAnnulus Annulus )
+	UITrackerDataUpdateEvent( const std::string& CacheName, const RangeAnnulus Annulus )
 		: CacheName( CacheName )
 		, Annulus( Annulus )
 	{
@@ -52,9 +52,9 @@ public:
 // -----------------------------------------------------------------------------
 
 template<>
-struct Utils::EventTraits< UITrackedCacheChangedEvent >
+struct Utils::EventTraits< UITrackerDataUpdateEvent >
 {
-	static constexpr char* Id = "SimCache.UITrackedCacheChangedEvent";
+	static constexpr char* Id = "SimCache.UITrackerDataUpdateEvent";
 };
 
 // -----------------------------------------------------------------------------

--- a/Source/SimCacheModule/Source/Events/UITrackerLoadedEvent.h
+++ b/Source/SimCacheModule/Source/Events/UITrackerLoadedEvent.h
@@ -6,7 +6,7 @@
 
 // -----------------------------------------------------------------------------
 
-class TrackerLoadedEvent
+class UITrackerLoadedEvent
 	: public Utils::Event
 {
 public:
@@ -18,9 +18,9 @@ public:
 // -----------------------------------------------------------------------------
 
 template<>
-struct Utils::EventTraits< TrackerLoadedEvent >
+struct Utils::EventTraits< UITrackerLoadedEvent >
 {
-	static constexpr char* Id = "SimCache.TrackerLoadedEvent";
+	static constexpr char* Id = "SimCache.UITrackerLoadedEvent";
 };
 
 // -----------------------------------------------------------------------------

--- a/Source/SimCacheModule/Source/Module/SimCacheModule.cpp
+++ b/Source/SimCacheModule/Source/Module/SimCacheModule.cpp
@@ -206,13 +206,19 @@ bool SimCacheModule::InitializeTrackerViewModel()
 		return false;
 	}
 
+	auto* CacheDataStorePtr = CacheDataStore.get();
+	if ( !CacheDataStorePtr )
+	{
+		return false;
+	}
+
 	auto* CacheTrackerPtr = CacheTracker.get();
 	if ( !CacheTrackerPtr )
 	{
 		return false;
 	}
 
-	TrackerVM = std::make_unique< TrackerViewModel >( *InternalEventDispatcherPtr , *JavaScriptEventDispatcherPtr, *CacheTrackerPtr );
+	TrackerVM = std::make_unique< TrackerViewModel >( *InternalEventDispatcherPtr , *JavaScriptEventDispatcherPtr, *CacheDataStorePtr, *CacheTrackerPtr );
 	if ( !TrackerVM )
 	{
 		return false;

--- a/Source/SimCacheModule/Source/Subsystems/CacheTracker/CacheTracker.h
+++ b/Source/SimCacheModule/Source/Subsystems/CacheTracker/CacheTracker.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "Core/CacheDefinitionCollection.h"
-#include "Core/TrackerState.h"
+#include "Core/RangeAnnulus.h"
 
 #include "Events/AircraftPositionUpdatedEvent.h"
 
@@ -37,18 +37,11 @@ public:
 	bool Initialize();
 	void Uninitialize();
 
+	const CacheDefinition* GetCurrentTrackedCache() const;
 	bool SetCurrentTrackedCache( const CacheId& Id );
 	void ClearCurrentTrackedCache();
 
-private:
-
-	void RegisterAircraftPositionUpdatedListener();
-	void UnregisterAircraftPositionUpdatedListener();
-	void OnAircraftPositionUpdated( const AircraftPositionUpdatedEvent& Event );
-
-	void UpdateTrackerState( const Utils::EarthCoordinate& CurrentPosition );
-
-	TrackerState GetCurrentAnnulus( const double RangeMeters ) const;
+	RangeAnnulus GetLastKnownAnnulus() const;
 
 private:
 
@@ -59,9 +52,23 @@ private:
 		const CacheId Id;
 		const CacheTrackerSettings TrackerSettings;
 		const Utils::EarthCoordinate GeocentricPosition;
-		TrackerState State;
+		RangeAnnulus Annulus;
 		bool InsideAlertRange;
 	};
+
+private:
+
+	void RegisterAircraftPositionUpdatedListener();
+	void UnregisterAircraftPositionUpdatedListener();
+	void OnAircraftPositionUpdated( const AircraftPositionUpdatedEvent& Event );
+
+	void Update( const Utils::EarthCoordinate& CurrentPosition );
+
+	bool UpdateAnnulus( TrackedCacheState& CacheState, const double RangeMeters );
+	bool CheckAlertRange( TrackedCacheState& CacheState, const double RangeMeters );
+	bool CheckAcquisitionRange( TrackedCacheState& CacheState, const double RangeMeters );
+
+	RangeAnnulus GetAnnulus( const double RangeMeters ) const;
 
 private:
 
@@ -71,10 +78,6 @@ private:
 	Utils::EventHandle OnAircraftPositionUpdatedEventHandle;
 
 	std::unique_ptr< TrackedCacheState > CurrentTrackedCache;
-
-public:
-
-	bool ForceNextTrackerStateUpdatedEvent;
 
 };
 

--- a/Source/SimCacheModule/Source/ViewModels/TrackerViewModel.cpp
+++ b/Source/SimCacheModule/Source/ViewModels/TrackerViewModel.cpp
@@ -4,7 +4,7 @@
 
 #include "Events/UICacheFoundEvent.h"
 #include "Events/UIRangeAnnulusChangedEvent.h"
-#include "Events/UITrackedCacheChangedEvent.h"
+#include "Events/UITrackerDataUpdateEvent.h"
 
 // -----------------------------------------------------------------------------
 
@@ -116,7 +116,7 @@ void TrackerViewModel::OnCacheFound( const CacheFoundEvent& Event )
 
 // -----------------------------------------------------------------------------
 
-void TrackerViewModel::SendUITrackedCacheChangedEvent( const CacheDefinition* Cache ) const
+void TrackerViewModel::SendUITrackerDataUpdateEvent( const CacheDefinition* Cache ) const
 {
 	if ( !Cache )
 	{
@@ -126,7 +126,7 @@ void TrackerViewModel::SendUITrackedCacheChangedEvent( const CacheDefinition* Ca
 	const auto Annulus = CacheTracker.GetLastKnownAnnulus();
 
 	// TODO: use appropriate localized text
-	GetViewEventDispatcher().FireEvent( UITrackedCacheChangedEvent( Cache->LocText[ 0 ].Text.Title, Annulus ) );
+	GetViewEventDispatcher().FireEvent( UITrackerDataUpdateEvent( Cache->LocText[ 0 ].Text.Title, Annulus ) );
 }
 
 // -----------------------------------------------------------------------------
@@ -134,7 +134,7 @@ void TrackerViewModel::SendUITrackedCacheChangedEvent( const CacheDefinition* Ca
 void TrackerViewModel::OnTrackerLoaded( const UITrackerLoadedEvent& Event )
 {
 	// the tracker InGamePanel opened; send full tracked cache data
-	SendUITrackedCacheChangedEvent( CacheTracker.GetCurrentTrackedCache() );
+	SendUITrackerDataUpdateEvent( CacheTracker.GetCurrentTrackedCache() );
 }
 
 // -----------------------------------------------------------------------------
@@ -142,7 +142,7 @@ void TrackerViewModel::OnTrackerLoaded( const UITrackerLoadedEvent& Event )
 void TrackerViewModel::OnTrackedCacheChangedEvent( const TrackedCacheChangedEvent& Event )
 {
 	// tracked cache changed; send full tracked cache data
-	SendUITrackedCacheChangedEvent( CacheDataStore.GetCacheDefinitionById( Event.NewCacheId ) );
+	SendUITrackerDataUpdateEvent( CacheDataStore.GetCacheDefinitionById( Event.NewCacheId ) );
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SimCacheModule/Source/ViewModels/TrackerViewModel.h
+++ b/Source/SimCacheModule/Source/ViewModels/TrackerViewModel.h
@@ -42,7 +42,7 @@ private:
 	void OnRangeAnnulusChanged( const RangeAnnulusChangedEvent& Event );
 	void OnCacheFound( const CacheFoundEvent& Event );
 
-	void SendUITrackedCacheChangedEvent( const CacheDefinition* Cache ) const;
+	void SendUITrackerDataUpdateEvent( const CacheDefinition* Cache ) const;
 
 private:
 

--- a/Source/SimCacheModule/Source/ViewModels/TrackerViewModel.h
+++ b/Source/SimCacheModule/Source/ViewModels/TrackerViewModel.h
@@ -3,8 +3,9 @@
 #pragma once
 
 #include "Events/CacheFoundEvent.h"
-#include "Events/TrackerLoadedEvent.h"
-#include "Events/TrackerStateUpdatedEvent.h"
+#include "Events/RangeAnnulusChangedEvent.h"
+#include "Events/TrackedCacheChangedEvent.h"
+#include "Events/UITrackerLoadedEvent.h"
 #include "Subsystems/CacheTracker/CacheTracker.h"
 #include "ViewModels/ViewModel.h"
 
@@ -24,7 +25,7 @@ class TrackerViewModel
 {
 public:
 
-	TrackerViewModel( Utils::NativeEventDispatcher& InternalEventDispatcher, Utils::EventDispatcher& ViewEventDispatcher, Subsystems::CacheTracker& CacheTracker );
+	TrackerViewModel( Utils::NativeEventDispatcher& InternalEventDispatcher, Utils::EventDispatcher& ViewEventDispatcher, const Subsystems::CacheDataStore& CacheDataStore, Subsystems::CacheTracker& CacheTracker );
 	virtual ~TrackerViewModel();
 
 	virtual bool Initialize() override final;
@@ -35,16 +36,22 @@ private:
 	void RegisterEventListeners();
 	void UnregisterEventListeners();
 
-	void OnTrackerLoaded( const TrackerLoadedEvent& Event );
-	void OnTrackerStateUpdated( const TrackerStateUpdatedEvent& Event );
+	void OnTrackerLoaded( const UITrackerLoadedEvent& Event );
+
+	void OnTrackedCacheChangedEvent( const TrackedCacheChangedEvent& Event );
+	void OnRangeAnnulusChanged( const RangeAnnulusChangedEvent& Event );
 	void OnCacheFound( const CacheFoundEvent& Event );
+
+	void SendUITrackedCacheChangedEvent( const CacheDefinition* Cache ) const;
 
 private:
 
+	const Subsystems::CacheDataStore& CacheDataStore;
 	Subsystems::CacheTracker& CacheTracker;
 
 	Utils::EventHandle OnTrackerLoadedEventHandle;
-	Utils::EventHandle OnTrackerStateUpdatedEventHandle;
+	Utils::EventHandle OnTrackedCacheChangedEventHandle;
+	Utils::EventHandle OnRangeAnnulusChangedEventHandle;
 	Utils::EventHandle OnCacheFoundEventHandle;
 
 };


### PR DESCRIPTION
Addresses issue #45:
- Improvements to Cache Tracker subsystem for better clarity
- Rename `TrackerState` enum to `RangeAnnulus`
- Remove `ForceNextTrackerStateUpdatedEvent` workaround
- Update range annulus tracker InGamePanel for new UI events / data
- Add new UI events; rename `TrackerLoadedEvent` to `UITrackerLoadedEvent`
- Improve tracker view model to better handle UI events and tracker load flow