### PR TITLE
Fix cache object manager initialization/uninitialization

### DIFF
--- a/Source/SimCacheModule/Source/Subsystems/CacheObjectManager/CacheObjectManager.cpp
+++ b/Source/SimCacheModule/Source/Subsystems/CacheObjectManager/CacheObjectManager.cpp
@@ -41,6 +41,11 @@ bool CacheObjectManager::Initialize()
 		return false;
 	}
 
+	if ( !RegisterCacheFoundEvent() )
+	{
+		return false;
+	}
+
 	return true;
 }
 
@@ -49,6 +54,7 @@ bool CacheObjectManager::Initialize()
 void CacheObjectManager::Uninitialize()
 {
 	UnregisterTrackedCacheChangedEvent();
+	UnregisterCacheFoundEvent();
 
 	if ( CacheObjectHandle.IsValid() )
 	{


### PR DESCRIPTION
Address issue #54 (should have noticed this in PR #35, sorry!) by making cache object manager correctly register and unregister the cache found event.